### PR TITLE
fix devshell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Rust / Cargo
 target/
+.direnv/
 
 # Nix
 result

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,8 @@
       shellHook = ''
         export PS1="(oxwm-dev) $PS1"
       '';
+
+      RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
     };
 
     formatter.${system} = pkgs.alejandra;

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
         pkgs.rustc
         pkgs.cargo
         pkgs.xorg.xorgserver
+        pkgs.xorg.xclock
         pkgs.xterm
         pkgs.just
       ];

--- a/flake.nix
+++ b/flake.nix
@@ -3,24 +3,26 @@
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
 
-  outputs = { self, nixpkgs }:
-    let
-      system = "x86_64-linux";
-      pkgs = import nixpkgs { inherit system; };
-    in
-    {
-      devShells.${system}.default = pkgs.mkShell {
-        buildInputs = [
-          pkgs.rustc
-          pkgs.cargo
-          pkgs.xorg.xorgserver
-          pkgs.xterm
-          pkgs.just
-        ];
-        shellHook = ''
-          export PS1="(oxwm-dev) $PS1"
-        '';
-      };
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    system = "x86_64-linux";
+    pkgs = import nixpkgs {inherit system;};
+  in {
+    devShells.${system}.default = pkgs.mkShell {
+      buildInputs = [
+        pkgs.rustc
+        pkgs.cargo
+        pkgs.xorg.xorgserver
+        pkgs.xterm
+        pkgs.just
+      ];
+      shellHook = ''
+        export PS1="(oxwm-dev) $PS1"
+      '';
     };
-}
 
+    formatter.${system} = pkgs.alejandra;
+  };
+}


### PR DESCRIPTION
Uhh improved flake? :joy:

- Added an envrc for convince of direnv users
- alejandra!!
- set `RUST_SRC_PATH`. This makes rust-analyzer happy, without this rust-analyzer wont work if its not the same version as devshells toolchain. It worked for you and turtle cause you both use nixpkgs stable
- add xclock to `buildInputs`