### PR TITLE
Add Makefile for easier installation and configuration

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -166,6 +166,13 @@ nix develop
 cargo build
 #+end_src
 
+* Installation with Make
+You can edit =config.mk= to customize your installation options before installing, and then, run:
+
+#+begin_src sh
+sudo make install
+#+end_src
+
 * Testing Xephyr with Justfile
 The =justfile= includes a =test= recipe that starts Xephyr on =:1=, launches
 test clients (xterm, xclock), and runs oxwm in the foreground.

--- a/src/bar/bar.rs
+++ b/src/bar/bar.rs
@@ -279,13 +279,10 @@ impl Bar {
                 }
             }
         }
-
         connection.flush()?;
-
         unsafe {
             x11::xlib::XFlush(self.display);
         }
-
         self.needs_redraw = false;
 
         Ok(())

--- a/src/keyboard/handlers.rs
+++ b/src/keyboard/handlers.rs
@@ -57,8 +57,6 @@ pub fn setup_keybinds(connection: &impl Connection, root: Window) -> Result<()> 
     for keybinding in KEYBINDINGS {
         let modifier_mask = modifiers_to_mask(keybinding.modifiers);
 
-        println!("Grabbing key {} with mod {}", keybinding.key, modifier_mask);
-
         connection.grab_key(
             false,
             root,


### PR DESCRIPTION
This patch introduces a Makefile to simplify building and installing the project.

- Provides a standard make workflow, which is more universal than just.
- Allows customization of PREFIX, PROFILE, and CC through the Makefile.
- Implements all features previously available in the Justfile.
- Updates README.org with installation instructions using make.

This makes it easier for users to build and install the project without requiring additional tools.