### PR TITLE
Change JetBrainsMono Nerd Font in config to standard monospace font

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ use x11rb::protocol::xproto::KeyButMask;
 pub const BORDER_WIDTH: u32 = 2;
 pub const BORDER_FOCUSED: u32 = 0x6dade3;
 pub const BORDER_UNFOCUSED: u32 = 0xbbbbbb;
-pub const FONT: &str = "JetBrainsMono Nerd Font:style=Bold:size=10";
+pub const FONT: &str = "monospace:size=10";
 
 // ========================================
 // GAPS (Vanity Gaps)


### PR DESCRIPTION
If someone does not have the specific nerd font installed it is problematic to have that as the default font, and they have to change it.

this PR sets the default font to `monospace`, which is a standard font alias everybody has on their system, it's usually set to something like DejaVu Sans Mono or Noto Sans Mono and the user can also change the font by either directly editing the `config.rs` or editing `~/.config/fontconfig/fonts.conf`