### PR TITLE
refactor: replace anyhow with explicit error types

### DIFF
--- a/src/bar/bar.rs
+++ b/src/bar/bar.rs
@@ -1,7 +1,7 @@
 use super::blocks::Block;
 use super::font::{Font, FontDraw};
 use crate::Config;
-use crate::window_manager::X11Error;
+use crate::errors::X11Error;
 use std::time::Instant;
 use x11rb::COPY_DEPTH_FROM_PARENT;
 use x11rb::connection::Connection;

--- a/src/bar/font.rs
+++ b/src/bar/font.rs
@@ -3,7 +3,7 @@ use x11::xft::{XftColor, XftDraw, XftDrawStringUtf8, XftFont, XftFontOpenName};
 use x11::xlib::{Colormap, Display, Drawable, Visual};
 use x11::xrender::XRenderColor;
 
-use crate::window_manager::X11Error;
+use crate::errors::X11Error;
 
 pub struct Font {
     xft_font: *mut XftFont,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,87 @@
+#[derive(Debug)]
+pub enum WmError {
+    X11(X11Error),
+    Io(std::io::Error),
+    Anyhow(anyhow::Error),
+}
+
+#[derive(Debug)]
+pub enum X11Error {
+    ConnectError(x11rb::errors::ConnectError),
+    ConnectionError(x11rb::errors::ConnectionError),
+    ReplyError(x11rb::errors::ReplyError),
+    ReplyOrIdError(x11rb::errors::ReplyOrIdError),
+    DisplayOpenFailed,
+    FontLoadFailed(String),
+    DrawCreateFailed,
+}
+
+impl std::fmt::Display for WmError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::X11(error) => write!(f, "{}", error),
+            Self::Io(error) => write!(f, "{}", error),
+            Self::Anyhow(error) => write!(f, "{}", error),
+        }
+    }
+}
+
+impl std::error::Error for WmError {}
+
+impl std::fmt::Display for X11Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ConnectError(err) => write!(f, "{}", err),
+            Self::ConnectionError(err) => write!(f, "{}", err),
+            Self::ReplyError(err) => write!(f, "{}", err),
+            Self::ReplyOrIdError(err) => write!(f, "{}", err),
+            Self::DisplayOpenFailed => write!(f, "failed to open X11 display"),
+            Self::FontLoadFailed(font_name) => write!(f, "failed to load Xft font: {}", font_name),
+            Self::DrawCreateFailed => write!(f, "failed to create XftDraw"),
+        }
+    }
+}
+
+impl std::error::Error for X11Error {}
+
+impl<T: Into<X11Error>> From<T> for WmError {
+    fn from(value: T) -> Self {
+        Self::X11(value.into())
+    }
+}
+
+impl From<std::io::Error> for WmError {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+impl From<anyhow::Error> for WmError {
+    fn from(value: anyhow::Error) -> Self {
+        Self::Anyhow(value)
+    }
+}
+
+impl From<x11rb::errors::ConnectError> for X11Error {
+    fn from(value: x11rb::errors::ConnectError) -> Self {
+        X11Error::ConnectError(value)
+    }
+}
+
+impl From<x11rb::errors::ConnectionError> for X11Error {
+    fn from(value: x11rb::errors::ConnectionError) -> Self {
+        X11Error::ConnectionError(value)
+    }
+}
+
+impl From<x11rb::errors::ReplyError> for X11Error {
+    fn from(value: x11rb::errors::ReplyError) -> Self {
+        X11Error::ReplyError(value)
+    }
+}
+
+impl From<x11rb::errors::ReplyOrIdError> for X11Error {
+    fn from(value: x11rb::errors::ReplyOrIdError) -> Self {
+        X11Error::ReplyOrIdError(value)
+    }
+}

--- a/src/keyboard/handlers.rs
+++ b/src/keyboard/handlers.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 use x11rb::connection::Connection;
 use x11rb::protocol::xproto::*;
 
-use crate::window_manager::X11Error;
+use crate::errors::X11Error;
 
 #[derive(Debug, Copy, Clone)]
 pub enum KeyAction {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod bar;
+pub mod errors;
 pub mod keyboard;
 pub mod layout;
 pub mod window_manager;

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -1,5 +1,6 @@
 use crate::Config;
 use crate::bar::Bar;
+use crate::errors::WmError;
 use crate::keyboard::{self, Arg, KeyAction, handlers};
 use crate::layout::GapConfig;
 use crate::layout::Layout;
@@ -34,93 +35,7 @@ pub struct WindowManager {
     bar: Bar,
 }
 
-#[derive(Debug)]
-pub enum WmError {
-    X11(X11Error),
-    Io(std::io::Error),
-    Anyhow(anyhow::Error),
-}
-
-#[derive(Debug)]
-pub enum X11Error {
-    ConnectError(x11rb::errors::ConnectError),
-    ConnectionError(x11rb::errors::ConnectionError),
-    ReplyError(x11rb::errors::ReplyError),
-    ReplyOrIdError(x11rb::errors::ReplyOrIdError),
-    DisplayOpenFailed,
-    FontLoadFailed(String),
-    DrawCreateFailed,
-}
-
 type WmResult<T> = Result<T, WmError>;
-
-impl std::fmt::Display for WmError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::X11(error) => write!(f, "{}", error),
-            Self::Io(error) => write!(f, "{}", error),
-            Self::Anyhow(error) => write!(f, "{}", error),
-        }
-    }
-}
-
-impl std::error::Error for WmError {}
-
-impl std::fmt::Display for X11Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::ConnectError(err) => write!(f, "{}", err),
-            Self::ConnectionError(err) => write!(f, "{}", err),
-            Self::ReplyError(err) => write!(f, "{}", err),
-            Self::ReplyOrIdError(err) => write!(f, "{}", err),
-            Self::DisplayOpenFailed => write!(f, "failed to open X11 display"),
-            Self::FontLoadFailed(font_name) => write!(f, "failed to load Xft font: {}", font_name),
-            Self::DrawCreateFailed => write!(f, "failed to create XftDraw"),
-        }
-    }
-}
-
-impl<T: Into<X11Error>> From<T> for WmError {
-    fn from(value: T) -> Self {
-        Self::X11(value.into())
-    }
-}
-
-impl From<std::io::Error> for WmError {
-    fn from(value: std::io::Error) -> Self {
-        Self::Io(value)
-    }
-}
-
-impl From<anyhow::Error> for WmError {
-    fn from(value: anyhow::Error) -> Self {
-        Self::Anyhow(value)
-    }
-}
-
-impl From<x11rb::errors::ConnectError> for X11Error {
-    fn from(value: x11rb::errors::ConnectError) -> Self {
-        X11Error::ConnectError(value)
-    }
-}
-
-impl From<x11rb::errors::ConnectionError> for X11Error {
-    fn from(value: x11rb::errors::ConnectionError) -> Self {
-        X11Error::ConnectionError(value)
-    }
-}
-
-impl From<x11rb::errors::ReplyError> for X11Error {
-    fn from(value: x11rb::errors::ReplyError) -> Self {
-        X11Error::ReplyError(value)
-    }
-}
-
-impl From<x11rb::errors::ReplyOrIdError> for X11Error {
-    fn from(value: x11rb::errors::ReplyOrIdError) -> Self {
-        X11Error::ReplyOrIdError(value)
-    }
-}
 
 impl WindowManager {
     pub fn new(config: Config) -> WmResult<Self> {


### PR DESCRIPTION
PR refactors all error handling at the library level, the bar(blocks not included), font, keyboard, and window manager modules to use concrete error types instead of `anyhow::Result`.

# Changed
- All custom errors are located in `src/errors.rs`:
  - `WmError`: top-level window manager error type. Caputres all failure paths.
  - `X11Error`: X11-specific errors e.g font loading, display open.
- Replaced `anyhow::Result` usages with `Result<_, WmError>` or `Result<_, X11Error>` across modules:
  - **bar/bar.rs**: now returns `Result<_, X11Error>`. With some infallible functions that aren't upholding a contract no longer returning `Result<_>`
  - **bar/font.rs**: now returns custom explicit font and draw creation errors
  - **keyboard/handlers.rs**: uses `io::Result` for spawn actions
  - **window_manager.rs**: unified `WmResult<T>` alias for cleaner function signatures
- Added `From` impls between all major X11 and std error types, makes new custom errors easy to use with `?`.
- Ensured traits object safety is consistent.

# Why
- Avoid `anyhow` abuse in core WM logic, prior to this all observable errors were just propagated up the stack with no one catching it at any level, resulting in meaningless crashes that are hard to debug.
- With concrete error types, function no longer fail with **opaque** BS, making structured error handling possible and better recoverability.
- Enables safe `?` propagation without losing error origin.

# Testing done? XD
- Compiles successfully (`cargo check`).
- Checked for new unknown behavior.
- Keyboard handler verified for spawn errors, I'm awesome ik :).

# Next Steps
- All new code should prefer the new error types over `anyhow::Result`