### PR TITLE
Fix zombie process via ignoring SIGCHLD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,7 @@ version = "0.8.1"
 dependencies = [
  "chrono",
  "dirs",
+ "libc",
  "mlua",
  "serde",
  "x11",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ chrono = "0.4"
 dirs = "5.0"
 serde = { version = "1.0", features = ["derive"] }
 mlua = { version = "0.10", features = ["lua54", "vendored"] }
+libc = "0.2"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -4,7 +4,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let arguments: Vec<String> = std::env::args().collect();
 
     let mut custom_config_path: Option<PathBuf> = None;
-
+    
+	unsafe {
+	       libc::signal(libc::SIGCHLD, libc::SIG_IGN);
+	}
+	
     match arguments.get(1).map(|string| string.as_str()) {
         Some("--version") => {
             println!("oxwm {}", env!("CARGO_PKG_VERSION"));


### PR DESCRIPTION
An attempt to fix zombie process described in issue #54. 
Don't know which way you want to take things.

Alternatively you can try something like

```
use nix::sys::signal::{signal, SigHandler, Signal};

unsafe {
    signal(Signal::SIGCHLD, SigHandler::SigIgn)
        .expect("Failed to ignore SIGCHLD");
}
```
