### PR TITLE
Replace display raw ptr by a wrapper to fix most clippy errors

### DIFF
--- a/src/overlay/error.rs
+++ b/src/overlay/error.rs
@@ -1,6 +1,7 @@
 use super::{Overlay, OverlayBase};
 use crate::bar::font::Font;
 use crate::errors::X11Error;
+use crate::window_manager::XLibDisplay;
 use x11rb::connection::Connection;
 use x11rb::protocol::xproto::*;
 use x11rb::rust_connection::RustConnection;
@@ -20,7 +21,7 @@ impl ErrorOverlay {
         connection: &RustConnection,
         screen: &Screen,
         screen_num: usize,
-        display: *mut x11::xlib::Display,
+        display: XLibDisplay,
         _font: &Font,
         _max_width: u16,
     ) -> Result<Self, X11Error> {
@@ -46,7 +47,7 @@ impl ErrorOverlay {
     pub fn show_error(
         &mut self,
         connection: &RustConnection,
-        font: &Font,
+        font: &mut Font,
         error_text: &str,
         monitor_x: i16,
         monitor_y: i16,
@@ -79,7 +80,7 @@ impl ErrorOverlay {
         Ok(())
     }
 
-    fn wrap_text(&self, text: &str, font: &Font, max_width: u16) -> Vec<String> {
+    fn wrap_text(&self, text: &str, font: &mut Font, max_width: u16) -> Vec<String> {
         let mut lines = Vec::new();
         for paragraph in text.lines() {
             if paragraph.trim().is_empty() {
@@ -128,7 +129,7 @@ impl Overlay for ErrorOverlay {
         Ok(())
     }
 
-    fn draw(&self, connection: &RustConnection, font: &Font) -> Result<(), X11Error> {
+    fn draw(&self, connection: &RustConnection, font: &mut Font) -> Result<(), X11Error> {
         if !self.base.is_visible {
             return Ok(());
         }

--- a/src/overlay/keybind.rs
+++ b/src/overlay/keybind.rs
@@ -3,6 +3,7 @@ use crate::bar::font::Font;
 use crate::errors::X11Error;
 use crate::keyboard::KeyAction;
 use crate::keyboard::handlers::{KeyBinding, KeyPress};
+use crate::window_manager::XLibDisplay;
 use std::time::Instant;
 use x11rb::connection::Connection;
 use x11rb::protocol::xproto::*;
@@ -30,7 +31,7 @@ impl KeybindOverlay {
         connection: &RustConnection,
         screen: &Screen,
         screen_num: usize,
-        display: *mut x11::xlib::Display,
+        display: XLibDisplay,
         modkey: KeyButMask,
     ) -> Result<Self, X11Error> {
         let base = OverlayBase::new(
@@ -59,7 +60,7 @@ impl KeybindOverlay {
     pub fn show(
         &mut self,
         connection: &RustConnection,
-        font: &Font,
+        font: &mut Font,
         keybindings: &[KeyBinding],
         monitor_x: i16,
         monitor_y: i16,
@@ -114,7 +115,7 @@ impl KeybindOverlay {
     pub fn toggle(
         &mut self,
         connection: &RustConnection,
-        font: &Font,
+        font: &mut Font,
         keybindings: &[KeyBinding],
         monitor_x: i16,
         monitor_y: i16,
@@ -260,7 +261,7 @@ impl Overlay for KeybindOverlay {
         Ok(())
     }
 
-    fn draw(&self, connection: &RustConnection, font: &Font) -> Result<(), X11Error> {
+    fn draw(&self, connection: &RustConnection, font: &mut Font) -> Result<(), X11Error> {
         if !self.base.is_visible {
             return Ok(());
         }

--- a/src/overlay/mod.rs
+++ b/src/overlay/mod.rs
@@ -1,5 +1,6 @@
 use crate::bar::font::{Font, FontDraw};
 use crate::errors::X11Error;
+use crate::window_manager::XLibDisplay;
 use x11rb::COPY_DEPTH_FROM_PARENT;
 use x11rb::connection::Connection;
 use x11rb::protocol::xproto::*;
@@ -15,7 +16,7 @@ pub trait Overlay {
     fn window(&self) -> Window;
     fn is_visible(&self) -> bool;
     fn hide(&mut self, connection: &RustConnection) -> Result<(), X11Error>;
-    fn draw(&self, connection: &RustConnection, font: &Font) -> Result<(), X11Error>;
+    fn draw(&self, connection: &RustConnection, font: &mut Font) -> Result<(), X11Error>;
 }
 
 pub struct OverlayBase {
@@ -34,7 +35,7 @@ impl OverlayBase {
         connection: &RustConnection,
         screen: &Screen,
         screen_num: usize,
-        display: *mut x11::xlib::Display,
+        mut display: XLibDisplay,
         width: u16,
         height: u16,
         border_width: u16,
@@ -73,8 +74,8 @@ impl OverlayBase {
 
         connection.flush()?;
 
-        let visual = unsafe { x11::xlib::XDefaultVisual(display, screen_num as i32) };
-        let colormap = unsafe { x11::xlib::XDefaultColormap(display, screen_num as i32) };
+        let visual = unsafe { x11::xlib::XDefaultVisual(display.as_mut(), screen_num as i32) };
+        let colormap = unsafe { x11::xlib::XDefaultColormap(display.as_mut(), screen_num as i32) };
 
         let font_draw = FontDraw::new(display, window as x11::xlib::Drawable, visual, colormap)?;
 


### PR DESCRIPTION
Fixes most clippy errors by using a wrapped ptr for display.

Had to turn most &Font to &mut Font too since XftTextExtentsUtf8 require a mut ptr (which propagate to text-width()