### PR TITLE
xsession file, checkinstall routine, indentation fix

### DIFF
--- a/justfile
+++ b/justfile
@@ -8,6 +8,9 @@ install: build
     @echo "✓ oxwm installed to /usr/bin/oxwm"
     @echo "  Run 'oxwm --init' to create your config"
 
+checkinstall:
+	checkinstall --pkgname oxwm --exclude /root -y just install
+
 uninstall:
     rm -f /usr/bin/oxwm
     @echo "✓ oxwm uninstalled"


### PR DESCRIPTION
A couple additions to the install routine:

* Create an xsession entry for display managers
* Add a "checkinstall" option to build deb (or rpm/slack) packages instead of normal install/copy

Additionally: 
* Fix indentation in justfile (in some instances tabs were used where the rest of the project appears to use 4 spaces)

### Things I'm not quite sure about
* does it make sense to put the desktop file in templates/ or is there a better place?
* is it correct to call checkinstall like that (i.e. calling just install again from the justfile) or is there a better way?

### Testing
* Run the normal installation routine (just install) on a system with a display manager(gdm, lightdm etc), verify you can select "oxwm" 
* Run "sudo just checkinstall", then verify "oxwm" package is installed in your package manager (e.g. dpkg -l oxwm on deb based distros)
* Verify indentation in justfile is consistent

I have tested all of these myself but of course it should be tested by someone else as well.

Feel free to cherry pick any of the commits if not all of this is desirable.