### PR TITLE
Cleanup and added focused window title to the wm bar

### DIFF
--- a/src/bar/font.rs
+++ b/src/bar/font.rs
@@ -1,9 +1,20 @@
 use std::ffi::CString;
 use x11::xft::{XftColor, XftDraw, XftDrawStringUtf8, XftFont, XftFontOpenName};
+use x11::xlib::_XDisplay;
 use x11::xlib::{Colormap, Display, Drawable, Visual};
 use x11::xrender::XRenderColor;
 
 use crate::errors::X11Error;
+
+enum DisplayAction {
+    Flush,
+    Sync,
+}
+
+enum FontAttribute {
+    Height,
+    Ascent,
+}
 
 pub struct Font {
     xft_font: *mut XftFont,
@@ -15,7 +26,7 @@ impl Font {
         let font_name_cstr =
             CString::new(font_name).map_err(|_| X11Error::FontLoadFailed(font_name.to_string()))?;
 
-        let xft_font = unsafe { XftFontOpenName(display, screen, font_name_cstr.as_ptr()) };
+        let xft_font = get_font(display, screen, font_name_cstr);
 
         if xft_font.is_null() {
             return Err(X11Error::FontLoadFailed(font_name.to_string()));
@@ -25,31 +36,15 @@ impl Font {
     }
 
     pub fn height(&self) -> u16 {
-        unsafe {
-            let font = &*self.xft_font;
-            font.height as u16
-        }
+        get_font_attribute(FontAttribute::Height, self.xft_font) as u16
     }
 
     pub fn ascent(&self) -> i16 {
-        unsafe {
-            let font = &*self.xft_font;
-            font.ascent as i16
-        }
+        get_font_attribute(FontAttribute::Ascent, self.xft_font) as i16
     }
 
     pub fn text_width(&self, text: &str) -> u16 {
-        unsafe {
-            let mut extents = std::mem::zeroed();
-            x11::xft::XftTextExtentsUtf8(
-                self.display,
-                self.xft_font,
-                text.as_ptr(),
-                text.len() as i32,
-                &mut extents,
-            );
-            extents.width
-        }
+        get_text_width(self, text)
     }
 }
 
@@ -74,7 +69,7 @@ impl FontDraw {
         visual: *mut Visual,
         colormap: Colormap,
     ) -> Result<Self, X11Error> {
-        let xft_draw = unsafe { x11::xft::XftDrawCreate(display, drawable, visual, colormap) };
+        let xft_draw = get_draw(display, drawable, visual, colormap);
 
         if xft_draw.is_null() {
             return Err(X11Error::DrawCreateFailed);
@@ -95,48 +90,15 @@ impl FontDraw {
             alpha: 0xFFFF,
         };
 
-        let mut xft_color: XftColor = unsafe { std::mem::zeroed() };
-
-        unsafe {
-            x11::xft::XftColorAllocValue(
-                x11::xft::XftDrawDisplay(self.xft_draw),
-                x11::xft::XftDrawVisual(self.xft_draw),
-                x11::xft::XftDrawColormap(self.xft_draw),
-                &render_color,
-                &mut xft_color,
-            );
-
-            XftDrawStringUtf8(
-                self.xft_draw,
-                &xft_color,
-                font.xft_font,
-                x as i32,
-                y as i32,
-                text.as_ptr(),
-                text.len() as i32,
-            );
-
-            x11::xft::XftColorFree(
-                x11::xft::XftDrawDisplay(self.xft_draw),
-                x11::xft::XftDrawVisual(self.xft_draw),
-                x11::xft::XftDrawColormap(self.xft_draw),
-                &mut xft_color,
-            );
-        }
+        do_draw(self.xft_draw, font, render_color, x, y, text);
     }
 
     pub fn flush(&self) {
-        unsafe {
-            let display = x11::xft::XftDrawDisplay(self.xft_draw);
-            x11::xlib::XFlush(display);
-        }
+        display_action(self.xft_draw, DisplayAction::Flush);
     }
 
     pub fn sync(&self) {
-        unsafe {
-            let display = x11::xft::XftDrawDisplay(self.xft_draw);
-            x11::xlib::XSync(display, 1);
-        }
+        display_action(self.xft_draw, DisplayAction::Sync);
     }
 }
 
@@ -165,11 +127,8 @@ impl DrawingSurface {
         visual: *mut Visual,
         colormap: Colormap,
     ) -> Result<Self, crate::errors::X11Error> {
-        let depth = unsafe { x11::xlib::XDefaultDepth(display, 0) };
-        let pixmap = unsafe {
-            x11::xlib::XCreatePixmap(display, window, width, height, depth as u32)
-        };
-
+        let depth = get_depth(display);
+        let pixmap = get_pixmap(display, window, width, height, depth as u32);
         let font_draw = FontDraw::new(display, pixmap, visual, colormap)?;
 
         Ok(Self {
@@ -195,5 +154,91 @@ impl Drop for DrawingSurface {
             self.font_draw.xft_draw = std::ptr::null_mut();
             x11::xlib::XFreePixmap(self.display, self.pixmap);
         }
+    }
+}
+
+fn get_font(display: *mut _XDisplay, screen: i32, font_name: CString) -> *mut XftFont {
+    unsafe { XftFontOpenName(display, screen, font_name.as_ptr()) }
+}
+
+fn get_draw(
+    display: *mut _XDisplay,
+    drawable: Drawable,
+    visual: *mut Visual,
+    colormap: Colormap,
+) -> *mut XftDraw {
+    unsafe { x11::xft::XftDrawCreate(display, drawable, visual, colormap) }
+}
+
+fn get_font_attribute(attrib: FontAttribute, font_ref: *mut XftFont) -> i32 {
+    unsafe {
+        let font = &*font_ref;
+        match attrib {
+            FontAttribute::Height => font.height,
+
+            FontAttribute::Ascent => font.ascent,
+        }
+    }
+}
+
+fn get_depth(display: *mut _XDisplay) -> i32 {
+    unsafe { x11::xlib::XDefaultDepth(display, 0) }
+}
+
+fn get_pixmap(display: *mut _XDisplay, window: u64, width: u32, height: u32, depth: u32) -> u64 {
+    unsafe { x11::xlib::XCreatePixmap(display, window, width, height, depth) }
+}
+
+fn get_text_width(font: &Font, text: &str) -> u16 {
+    unsafe {
+        let mut extents = std::mem::zeroed();
+        x11::xft::XftTextExtentsUtf8(
+            font.display,
+            font.xft_font,
+            text.as_ptr(),
+            text.len() as i32,
+            &mut extents,
+        );
+        extents.width
+    }
+}
+
+fn display_action(font_draw: *mut XftDraw, action: DisplayAction) {
+    unsafe {
+        let display = x11::xft::XftDrawDisplay(font_draw);
+        match action {
+            DisplayAction::Flush => x11::xlib::XFlush(display),
+            DisplayAction::Sync => x11::xlib::XSync(display, 1),
+        };
+    }
+}
+
+fn do_draw(font_draw: *mut XftDraw, font: &Font, color: XRenderColor, x: i16, y: i16, text: &str) {
+    unsafe {
+        let mut xft_color: XftColor = std::mem::zeroed();
+        x11::xft::XftColorAllocValue(
+            x11::xft::XftDrawDisplay(font_draw),
+            x11::xft::XftDrawVisual(font_draw),
+            x11::xft::XftDrawColormap(font_draw),
+            &color,
+            &mut xft_color,
+        );
+
+        XftDrawStringUtf8(
+            font_draw,
+            &xft_color,
+            font.xft_font,
+            x as i32,
+            y as i32,
+            text.as_ptr(),
+            text.len() as i32,
+        );
+
+        x11::xft::XftColorFree(
+            x11::xft::XftDrawDisplay(font_draw),
+            x11::xft::XftDrawVisual(font_draw),
+            x11::xft::XftDrawColormap(font_draw),
+            &mut xft_color,
+        );
     }
 }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -37,16 +37,21 @@ impl Pertag {
 }
 
 #[derive(Debug, Clone)]
+pub struct ScreenInfo {
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+}
+
+#[derive(Debug, Clone)]
 pub struct Monitor {
     pub layout_symbol: String,
     pub master_factor: f32,
     pub num_master: i32,
     pub monitor_number: usize,
     pub bar_y_position: i32,
-    pub screen_x: i32,
-    pub screen_y: i32,
-    pub screen_width: i32,
-    pub screen_height: i32,
+    pub screen_info: ScreenInfo,
     pub window_area_x: i32,
     pub window_area_y: i32,
     pub window_area_width: i32,
@@ -77,10 +82,12 @@ impl Monitor {
             num_master: 1,
             monitor_number: 0,
             bar_y_position: 0,
-            screen_x: x,
-            screen_y: y,
-            screen_width: width as i32,
-            screen_height: height as i32,
+            screen_info: ScreenInfo {
+                x,
+                y,
+                width: width as i32,
+                height: height as i32,
+            },
             window_area_x: x,
             window_area_y: y,
             window_area_width: width as i32,
@@ -115,10 +122,10 @@ impl Monitor {
     }
 
     pub fn contains_point(&self, x: i32, y: i32) -> bool {
-        x >= self.screen_x
-            && x < self.screen_x + self.screen_width
-            && y >= self.screen_y
-            && y < self.screen_y + self.screen_height
+        x >= self.screen_info.x
+            && x < self.screen_info.x + self.screen_info.width
+            && y >= self.screen_info.y
+            && y < self.screen_info.y + self.screen_info.height
     }
 
     pub fn get_selected_tag(&self) -> TagMask {
@@ -168,10 +175,10 @@ pub fn detect_monitors(
             let height_in_pixels = screen_info.height as u32;
 
             let is_duplicate_monitor = monitors.iter().any(|monitor| {
-                monitor.screen_x == x_position
-                    && monitor.screen_y == y_position
-                    && monitor.screen_width == width_in_pixels as i32
-                    && monitor.screen_height == height_in_pixels as i32
+                monitor.screen_info.x == x_position
+                    && monitor.screen_info.y == y_position
+                    && monitor.screen_info.width == width_in_pixels as i32
+                    && monitor.screen_info.height == height_in_pixels as i32
             });
 
             if !is_duplicate_monitor {
@@ -189,8 +196,8 @@ pub fn detect_monitors(
         monitors = fallback_monitors();
     }
 
-    monitors.sort_by(|a, b| match a.screen_y.cmp(&b.screen_y) {
-        std::cmp::Ordering::Equal => a.screen_x.cmp(&b.screen_x),
+    monitors.sort_by(|a, b| match a.screen_info.y.cmp(&b.screen_info.y) {
+        std::cmp::Ordering::Equal => a.screen_info.x.cmp(&b.screen_info.x),
         other => other,
     });
 

--- a/src/overlay/mod.rs
+++ b/src/overlay/mod.rs
@@ -1,5 +1,6 @@
 use crate::bar::font::{Font, FontDraw};
 use crate::errors::X11Error;
+use x11::xlib::_XDisplay;
 use x11rb::COPY_DEPTH_FROM_PARENT;
 use x11rb::connection::Connection;
 use x11rb::protocol::xproto::*;
@@ -73,8 +74,7 @@ impl OverlayBase {
 
         connection.flush()?;
 
-        let visual = unsafe { x11::xlib::XDefaultVisual(display, screen_num as i32) };
-        let colormap = unsafe { x11::xlib::XDefaultColormap(display, screen_num as i32) };
+        let (visual, colormap) = get_visual_and_colormap(display, screen_num as i32);
 
         let font_draw = FontDraw::new(display, window as x11::xlib::Drawable, visual, colormap)?;
 
@@ -152,5 +152,17 @@ impl OverlayBase {
             }],
         )?;
         Ok(())
+    }
+}
+
+fn get_visual_and_colormap(
+    display: *mut _XDisplay,
+    screen_num: i32,
+) -> (*mut x11::xlib::Visual, u64) {
+    unsafe {
+        (
+            x11::xlib::XDefaultVisual(display, screen_num),
+            x11::xlib::XDefaultColormap(display, screen_num),
+        )
     }
 }


### PR DESCRIPTION
I figured I would play around with this a little more. This should check off having the focused window title in the bar.
Also, it appears that add/hide empty tag numbers is already working. 
