### PR TITLE
Add Home Manager configuration validation

### DIFF
--- a/hm.nix
+++ b/hm.nix
@@ -61,7 +61,7 @@
       ++ optional (rule.floating != null) ''floating = ${boolToString rule.floating}''
       ++ optional (rule.tag != null) ''tag = ${toString rule.tag}''
       ++ optional (rule.fullscreen != null) ''fullscreen = ${boolToString rule.fullscreen}''
-      ++ optional (rule.focus != null) ''focus = ${boolToString rule.fullscreen}''
+      ++ optional (rule.focus != null) ''focus = ${boolToString rule.focus}''
     );
   in "oxwm.rule.add({ ${fields} })";
 


### PR DESCRIPTION
This PR uses `oxwm --validate` to check the validity of the config.lua generated by the Home Manager module before rebuilding the NixOS or Home Manager generation. It also fixes a typo that caused a bug with window rules applying focus.

Here is a demonstration of it catching a broken config after it was generated.
https://github.com/user-attachments/assets/8905bf3e-d0f0-4cc1-a603-d4406ab047bf