### PR TITLE
Added state-specific colors to battery block.

### DIFF
--- a/resources/test-config.lua
+++ b/resources/test-config.lua
@@ -166,6 +166,9 @@ oxwm.bar.set_blocks({
         fmt_full = "✓ Bat: {}%",
         interval = 30,
         color = colors.green,
+        color_charging = colors.cyan,
+        color_discharging = colors.red,
+        color_full = colors.green,
         underline = true,
         battery_name = "BAT1"
     }),

--- a/src/bar/blocks/battery.zig
+++ b/src/bar/blocks/battery.zig
@@ -8,6 +8,10 @@ pub const Battery = struct {
     battery_name: []const u8,
     interval_secs: u64,
     color: c_ulong,
+    color_charging: ?c_ulong,
+    color_discharging: ?c_ulong,
+    color_full: ?c_ulong,
+    current_status: ?Status = null,
 
     pub fn init(
         format_charging: []const u8,
@@ -16,6 +20,9 @@ pub const Battery = struct {
         battery_name: []const u8,
         interval_secs: u64,
         color: c_ulong,
+        color_charging: ?c_ulong,
+        color_discharging: ?c_ulong,
+        color_full: ?c_ulong,
     ) Battery {
         return .{
             .format_charging = format_charging,
@@ -24,6 +31,9 @@ pub const Battery = struct {
             .battery_name = if (battery_name.len > 0) battery_name else "BAT0",
             .interval_secs = interval_secs,
             .color = color,
+            .color_charging = color_charging,
+            .color_discharging = color_discharging,
+            .color_full = color_full,
         };
     }
 
@@ -32,6 +42,8 @@ pub const Battery = struct {
 
         const capacity = self.read_battery_file(&path_buf, "capacity") orelse return buffer[0..0];
         const status = self.read_battery_status(&path_buf) orelse return buffer[0..0];
+        
+        self.current_status = status;
 
         const format = switch (status) {
             .charging => self.format_charging,
@@ -82,6 +94,13 @@ pub const Battery = struct {
     }
 
     pub fn get_color(self: *Battery) c_ulong {
+        if (self.current_status) |status| {
+            return switch (status) {
+                .charging => self.color_charging orelse self.color,
+                .discharging => self.color_discharging orelse self.color,
+                .full => self.color_full orelse self.color,
+            };
+        }
         return self.color;
     }
 };

--- a/src/bar/blocks/blocks.zig
+++ b/src/bar/blocks/blocks.zig
@@ -73,10 +73,13 @@ pub const Block = struct {
         battery_name: []const u8,
         interval_secs: u64,
         col: c_ulong,
+        color_charging: ?c_ulong,
+        color_discharging: ?c_ulong,
+        color_full: ?c_ulong,
         ul: bool,
     ) Block {
         return .{
-            .data = .{ .battery = Battery.init(format_charging, format_discharging, format_full, battery_name, interval_secs, col) },
+            .data = .{ .battery = Battery.init(format_charging, format_discharging, format_full, battery_name, interval_secs, col, color_charging, color_discharging, color_full) },
             .last_update = 0,
             .cached_content = undefined,
             .cached_len = 0,

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -99,6 +99,9 @@ pub const Block = struct {
     format_discharging: ?[]const u8 = null,
     format_full: ?[]const u8 = null,
     battery_name: ?[]const u8 = null,
+    color_charging: ?u32 = null,
+    color_discharging: ?u32 = null,
+    color_full: ?u32 = null,
     thermal_zone: ?[]const u8 = null,
 };
 

--- a/src/config/lua.zig
+++ b/src/config/lua.zig
@@ -852,6 +852,24 @@ fn parse_block_config(state: *c.lua_State, idx: c_int) ?Block {
             _ = c.lua_getfield(state, -1, "battery_name");
             block.battery_name = dupe_lua_string(state, -1);
             c.lua_settop(state, -2);
+
+            _ = c.lua_getfield(state, -1, "color_charging");
+            if (c.lua_type(state, -1) != c.LUA_TNIL) {
+                block.color_charging = parse_color(state, -1);
+            }
+            c.lua_settop(state, -2);
+
+            _ = c.lua_getfield(state, -1, "color_discharging");
+            if (c.lua_type(state, -1) != c.LUA_TNIL) {
+                block.color_discharging = parse_color(state, -1);
+            }
+            c.lua_settop(state, -2);
+
+            _ = c.lua_getfield(state, -1, "color_full");
+            if (c.lua_type(state, -1) != c.LUA_TNIL) {
+                block.color_full = parse_color(state, -1);
+            }
+            c.lua_settop(state, -2);
         }
         c.lua_settop(state, -2);
     } else {
@@ -949,7 +967,7 @@ fn lua_bar_block_battery(state: ?*c.lua_State) callconv(.c) c_int {
     _ = c.lua_getfield(s, 1, "underline");
     c.lua_setfield(s, -2, "underline");
 
-    c.lua_createtable(s, 0, 4);
+    c.lua_createtable(s, 0, 7);
     _ = c.lua_getfield(s, 1, "charging");
     c.lua_setfield(s, -2, "charging");
     _ = c.lua_getfield(s, 1, "discharging");
@@ -958,6 +976,12 @@ fn lua_bar_block_battery(state: ?*c.lua_State) callconv(.c) c_int {
     c.lua_setfield(s, -2, "full");
     _ = c.lua_getfield(s, 1, "battery_name");
     c.lua_setfield(s, -2, "battery_name");
+    _ = c.lua_getfield(s, 1, "color_charging");
+    c.lua_setfield(s, -2, "color_charging");
+    _ = c.lua_getfield(s, 1, "color_discharging");
+    c.lua_setfield(s, -2, "color_discharging");
+    _ = c.lua_getfield(s, 1, "color_full");
+    c.lua_setfield(s, -2, "color_full");
     c.lua_setfield(s, -2, "__arg");
 
     return 1;

--- a/src/main.zig
+++ b/src/main.zig
@@ -378,6 +378,9 @@ fn config_block_to_bar_block(cfg: config_mod.Block) blocks_mod.Block {
             cfg.battery_name orelse "BAT0",
             cfg.interval,
             cfg.color,
+            if (cfg.color_charging) |c| @as(c_ulong, c) else null,
+            if (cfg.color_discharging) |c| @as(c_ulong, c) else null,
+            if (cfg.color_full) |c| @as(c_ulong, c) else null,
             cfg.underline,
         ),
         .cpu_temp => blocks_mod.Block.init_cpu_temp(

--- a/templates/config.lua
+++ b/templates/config.lua
@@ -91,6 +91,9 @@ local blocks = {
         full = "✓ Bat: {}%",
         interval = 30,
         color = colors.green,
+        color_charging = colors.cyan,
+        color_discharging = colors.red,
+        color_full = colors.green,
         underline = true,
     }),
 };

--- a/templates/oxwm.lua
+++ b/templates/oxwm.lua
@@ -295,7 +295,7 @@ function oxwm.bar.block.shell(config) end
 function oxwm.bar.block.static(config) end
 
 ---Create a battery status block
----@param config {format: string, charging: string, discharging: string, full: string, interval: integer, color: string|integer, underline: boolean, battery_name: string} Block configuration
+---@param config {format: string, charging: string, discharging: string, full: string, interval: integer, color: string|integer, color_charging: string|integer|nil, color_discharging: string|integer|nil, color_full: string|integer|nil, underline: boolean, battery_name: string} Block configuration
 ---@return table Block configuration
 function oxwm.bar.block.battery(config) end
 


### PR DESCRIPTION
Adds support for color_charging, color_discharging, and color_full to the battery status block.

config example:

```lua
oxwm.bar.block.battery({
       color = "#ffffff", -- default
       color_charging = "#00ff00",
       color_discharging = "#ff0000",
})
```