### PR TITLE
Features : Quality of life

### DIFF
--- a/src/bar/bar.zig
+++ b/src/bar/bar.zig
@@ -73,11 +73,23 @@ pub const Bar = struct {
         const font_height = font.*.ascent + font.*.descent;
         const bar_height: i32 = @intCast(@as(i32, font_height) + 8);
 
+        var bar_y: i32 = 0;
+
+        if (std.mem.eql(u8, config.bar_position, "top")) {
+            bar_y = monitor.mon_y;
+            monitor.mon_y = monitor.mon_y + bar_height;
+        } else if (std.mem.eql(u8, config.bar_position, "bottom")) {
+            bar_y = monitor.mon_h - bar_height;
+            monitor.mon_y = 0;
+        } else {
+            return null;
+        }
+
         const window = xlib.c.XCreateSimpleWindow(
             display,
             root,
             monitor.mon_x,
-            monitor.mon_y,
+            bar_y,
             @intCast(monitor.mon_w),
             @intCast(bar_height),
             0,
@@ -125,7 +137,6 @@ pub const Bar = struct {
         };
 
         monitor.bar_win = window;
-        monitor.win_y = monitor.mon_y + bar_height;
         monitor.win_h = monitor.mon_h - bar_height;
 
         return bar;

--- a/src/bar/bar.zig
+++ b/src/bar/bar.zig
@@ -217,6 +217,8 @@ pub const Bar = struct {
             const content = block.getContent();
             const content_width = self.textWidth(display, content);
             block_x -= content_width;
+            block.x_start = block_x;
+            block.x_end = block_x + content_width;
             self.drawText(display, block_x, @divTrunc(self.height + self.font_height, 2) - 4, content, block.color());
             if (block.underline) {
                 self.fillRect(display, block_x, self.height - 2, content_width, 2, block.color());
@@ -252,6 +254,16 @@ pub const Bar = struct {
                 return index;
             }
             x_position += tag_width;
+        }
+        return null;
+    }
+
+    /// Returns the click action of the block the user clicked on, or null.
+    pub fn handleBlockClick(self: *Bar, click_x: i32) ?config_mod.ClickAction {
+        for (self.blocks.items) |*block| {
+            if (block.click != null and click_x >= block.x_start and click_x < block.x_end) {
+                return block.click;
+            }
         }
         return null;
     }

--- a/src/bar/bar.zig
+++ b/src/bar/bar.zig
@@ -77,10 +77,10 @@ pub const Bar = struct {
 
         if (std.mem.eql(u8, config.bar_position, "top")) {
             bar_y = monitor.mon_y;
-            monitor.mon_y = monitor.mon_y + bar_height;
+            monitor.win_y = monitor.mon_y + bar_height;
         } else if (std.mem.eql(u8, config.bar_position, "bottom")) {
-            bar_y = monitor.mon_h - bar_height;
-            monitor.mon_y = 0;
+            bar_y = monitor.mon_y + monitor.mon_h - bar_height;
+            monitor.win_y = monitor.mon_y;
         } else {
             return null;
         }

--- a/src/bar/bar.zig
+++ b/src/bar/bar.zig
@@ -9,13 +9,13 @@ const Monitor = monitor_mod.Monitor;
 const Block = blocks_mod.Block;
 
 fn getLayoutSymbol(layout_index: u32, config: config_mod.Config) []const u8 {
-    return switch (layout_index) {
-        0 => config.layout_tile_symbol,
-        1 => config.layout_monocle_symbol,
-        2 => config.layout_floating_symbol,
-        3 => config.layout_scrolling_symbol,
-        4 => "[#]",
-        else => "[?]",
+    const layout = std.meta.intToEnum(config_mod.Layouts, layout_index) catch return "[?]";
+    return switch (layout) {
+        .tiling => config.layout_tile_symbol,
+        .monocle => config.layout_monocle_symbol,
+        .floating => config.layout_floating_symbol,
+        .scrolling => config.layout_scrolling_symbol,
+        .grid => config.layout_grid_symbol,
     };
 }
 

--- a/src/bar/blocks/blocks.zig
+++ b/src/bar/blocks/blocks.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const config_mod = @import("../../config/config.zig");
 
 pub const Static = @import("static.zig").Static;
 pub const DateTime = @import("datetime.zig").DateTime;
@@ -13,6 +14,9 @@ pub const Block = struct {
     cached_content: [256]u8,
     cached_len: usize,
     underline: bool,
+    click: ?config_mod.ClickAction = null,
+    x_start: i32 = 0,
+    x_end: i32 = 0,
 
     pub const Data = union(enum) {
         static: Static,

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -148,6 +148,7 @@ pub const FloatingPosition = enum {
 pub const ClickAction = struct {
     command: []const u8,
     floating: bool = false,
+    bypass_rules: bool = false,
 };
 
 pub const Block = struct {

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -86,6 +86,15 @@ pub const Layouts = enum(u32) {
     floating,
     scrolling,
     grid,
+
+    pub fn fromString(name: []const u8) ?Layouts {
+        if (std.meta.stringToEnum(Layouts, name)) |v| return v;
+        if (std.mem.eql(u8, name, "tile")) return .tiling;
+        if (std.mem.eql(u8, name, "normie")) return .floating;
+        if (std.mem.eql(u8, name, "float")) return .floating;
+        if (std.mem.eql(u8, name, "scroll")) return .scrolling;
+        return null;
+    }
 };
 
 pub const MouseButton = struct {
@@ -125,6 +134,7 @@ pub const Config = struct {
     bar_position: []const u8 = "top",
     tags: [9][]const u8 = .{ "1", "2", "3", "4", "5", "6", "7", "8", "9" },
     layout: []const u8 = "tiling",
+    tag_layouts: [9]?[]const u8 = .{null} ** 9,
 
     border_width: i32 = 2,
     border_focused: u32 = 0x6dade3,

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -146,6 +146,7 @@ pub const Config = struct {
     layout_monocle_symbol: []const u8 = "[M]",
     layout_floating_symbol: []const u8 = "><>",
     layout_scrolling_symbol: []const u8 = "[S]",
+    layout_grid_symbol: []const u8 = "[#]",
 
     scheme_normal: ColorScheme = .{ .foreground = 0xbbbbbb, .background = 0x1a1b26, .border = 0x444444 },
     scheme_selected: ColorScheme = .{ .foreground = 0x0db9d7, .background = 0x1a1b26, .border = 0xad8ee6 },

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -80,6 +80,14 @@ pub const MouseAction = enum {
     toggle_floating,
 };
 
+pub const Layouts = enum(u32) {
+    tiling,
+    monocle,
+    floating,
+    scrolling,
+    grid,
+};
+
 pub const MouseButton = struct {
     click: ClickTarget,
     mod_mask: u32,
@@ -115,6 +123,7 @@ pub const Config = struct {
     terminal: []const u8 = "st",
     font: []const u8 = "monospace:size=10",
     tags: [9][]const u8 = .{ "1", "2", "3", "4", "5", "6", "7", "8", "9" },
+    layout: []const u8 = "tiling",
 
     border_width: i32 = 2,
     border_focused: u32 = 0x6dade3,

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -18,6 +18,7 @@ pub const Action = enum {
     toggle_floating,
     toggle_fullscreen,
     toggle_gaps,
+    toggle_bar,
     cycle_layout,
     set_layout,
     set_layout_tiling,

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -105,6 +105,11 @@ pub const MouseButton = struct {
     action: MouseAction,
 };
 
+pub const ClickAction = struct {
+    command: []const u8,
+    floating: bool = false,
+};
+
 pub const Block = struct {
     block_type: BlockType,
     format: []const u8,
@@ -118,6 +123,7 @@ pub const Block = struct {
     format_full: ?[]const u8 = null,
     battery_name: ?[]const u8 = null,
     thermal_zone: ?[]const u8 = null,
+    click: ?ClickAction = null,
 };
 
 pub const ColorScheme = struct {

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -122,6 +122,7 @@ pub const Config = struct {
 
     terminal: []const u8 = "st",
     font: []const u8 = "monospace:size=10",
+    bar_position: []const u8 = "top",
     tags: [9][]const u8 = .{ "1", "2", "3", "4", "5", "6", "7", "8", "9" },
     layout: []const u8 = "tiling",
 

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -105,6 +105,46 @@ pub const MouseButton = struct {
     action: MouseAction,
 };
 
+pub const FloatingPosition = enum {
+    top_left,
+    top_center,
+    top_right,
+    center_left,
+    center,
+    center_right,
+    bottom_left,
+    bottom_center,
+    bottom_right,
+
+    pub fn fromString(name: []const u8) ?FloatingPosition {
+        const map = .{
+            .{ "top-left", .top_left },
+            .{ "top_left", .top_left },
+            .{ "top-center", .top_center },
+            .{ "top_center", .top_center },
+            .{ "top-middle", .top_center },
+            .{ "top-right", .top_right },
+            .{ "top_right", .top_right },
+            .{ "center-left", .center_left },
+            .{ "center_left", .center_left },
+            .{ "center", .center },
+            .{ "center-right", .center_right },
+            .{ "center_right", .center_right },
+            .{ "bottom-left", .bottom_left },
+            .{ "bottom_left", .bottom_left },
+            .{ "bottom-center", .bottom_center },
+            .{ "bottom_center", .bottom_center },
+            .{ "bottom-middle", .bottom_center },
+            .{ "bottom-right", .bottom_right },
+            .{ "bottom_right", .bottom_right },
+        };
+        inline for (map) |entry| {
+            if (std.mem.eql(u8, name, entry[0])) return entry[1];
+        }
+        return null;
+    }
+};
+
 pub const ClickAction = struct {
     command: []const u8,
     floating: bool = false,
@@ -158,6 +198,7 @@ pub const Config = struct {
     auto_tile: bool = false,
     tag_back_and_forth: bool = false,
     hide_vacant_tags: bool = false,
+    floating_position: FloatingPosition = .center,
 
     layout_tile_symbol: []const u8 = "[]=",
     layout_monocle_symbol: []const u8 = "[M]",

--- a/src/config/lua.zig
+++ b/src/config/lua.zig
@@ -1252,7 +1252,11 @@ fn parseClickAction(state: *c.lua_State, idx: c_int) ?config_mod.ClickAction {
         const floating = c.lua_toboolean(state, -1) != 0;
         c.lua_settop(state, -2);
 
-        return .{ .command = cmd.?, .floating = floating };
+        _ = c.lua_getfield(state, idx, "bypass_rules");
+        const bypass_rules = c.lua_toboolean(state, -1) != 0;
+        c.lua_settop(state, -2);
+
+        return .{ .command = cmd.?, .floating = floating, .bypass_rules = bypass_rules };
     }
     return null;
 }

--- a/src/config/lua.zig
+++ b/src/config/lua.zig
@@ -338,6 +338,9 @@ fn registerMiscFunctions(state: *c.lua_State) void {
 
     c.lua_pushcfunction(state, luaIncNumMaster);
     c.lua_setfield(state, -2, "inc_num_master");
+
+    c.lua_pushcfunction(state, luaSetTagLayout);
+    c.lua_setfield(state, -2, "set_tag_layout");
 }
 
 fn createActionTable(state: *c.lua_State, action_name: [*:0]const u8) void {
@@ -1083,23 +1086,29 @@ fn luaSetLayoutSymbol(state: ?*c.lua_State) callconv(.c) c_int {
     const name = getStringArg(s, 1) orelse return 0;
     const symbol = dupeLuaString(s, 2) orelse return 0;
 
-    const layout_map = .{
-        .{ "tiling", &cfg.layout_tile_symbol },
-        .{ "tile", &cfg.layout_tile_symbol },
-        .{ "normie", &cfg.layout_floating_symbol },
-        .{ "floating", &cfg.layout_floating_symbol },
-        .{ "float", &cfg.layout_floating_symbol },
-        .{ "monocle", &cfg.layout_monocle_symbol },
-        .{ "scrolling", &cfg.layout_scrolling_symbol },
-        .{ "scroll", &cfg.layout_scrolling_symbol },
-        .{ "grid", &cfg.layout_grid_symbol },
-    };
+    const layout = config_mod.Layouts.fromString(name) orelse return 0;
+    switch (layout) {
+        .tiling => cfg.layout_tile_symbol = symbol,
+        .monocle => cfg.layout_monocle_symbol = symbol,
+        .floating => cfg.layout_floating_symbol = symbol,
+        .scrolling => cfg.layout_scrolling_symbol = symbol,
+        .grid => cfg.layout_grid_symbol = symbol,
+    }
+    return 0;
+}
 
-    inline for (layout_map) |entry| {
-        if (std.mem.eql(u8, name, entry[0])) {
-            entry[1].* = symbol;
-            return 0;
-        }
+fn luaSetTagLayout(state: ?*c.lua_State) callconv(.c) c_int {
+    const cfg = config orelse return 0;
+    const s = state orelse return 0;
+    const tag_index = c.lua_tointegerx(s, 1, null);
+    if (tag_index < 1 or tag_index > 9) return 0;
+    const name = getStringArg(s, 2) orelse return 0;
+    if (config_mod.Layouts.fromString(name) == null) {
+        std.debug.print("set_tag_layout: unknown layout '{s}'\n", .{name});
+        return 0;
+    }
+    if (dupeLuaString(s, 2)) |layout_str| {
+        cfg.tag_layouts[@intCast(tag_index - 1)] = layout_str;
     }
     return 0;
 }

--- a/src/config/lua.zig
+++ b/src/config/lua.zig
@@ -300,6 +300,9 @@ fn registerMiscFunctions(state: *c.lua_State) void {
     c.lua_pushcfunction(state, luaSetTerminal);
     c.lua_setfield(state, -2, "set_terminal");
 
+    c.lua_pushcfunction(state, luaSetLayout);
+    c.lua_setfield(state, -2, "set_layout");
+
     c.lua_pushcfunction(state, luaSetModkey);
     c.lua_setfield(state, -2, "set_modkey");
 
@@ -993,6 +996,15 @@ fn luaSetTerminal(state: ?*c.lua_State) callconv(.c) c_int {
     const s = state orelse return 0;
     if (dupeLuaString(s, 1)) |term| {
         cfg.terminal = term;
+    }
+    return 0;
+}
+
+fn luaSetLayout(state: ?*c.lua_State) callconv(.c) c_int {
+    const cfg = config orelse return 0;
+    const s = state orelse return 0;
+    if (dupeLuaString(s, 1)) |layout| {
+        cfg.layout = layout;
     }
     return 0;
 }

--- a/src/config/lua.zig
+++ b/src/config/lua.zig
@@ -823,12 +823,17 @@ fn parseBlockConfig(state: *c.lua_State, idx: c_int) ?Block {
     const underline = c.lua_toboolean(state, -1) != 0;
     c.lua_settop(state, -2);
 
+    _ = c.lua_getfield(state, idx, "click");
+    const click = parseClickAction(state, -1);
+    c.lua_settop(state, -2);
+
     var block = Block{
         .block_type = .static,
         .format = format,
         .interval = interval,
         .color = color,
         .underline = underline,
+        .click = click,
     };
 
     if (std.mem.eql(u8, block_type_str, "Ram")) {
@@ -949,7 +954,7 @@ fn luaBarBlockStatic(state: ?*c.lua_State) callconv(.c) c_int {
 fn luaBarBlockBattery(state: ?*c.lua_State) callconv(.c) c_int {
     const s = state orelse return 0;
 
-    c.lua_createtable(s, 0, 6);
+    c.lua_createtable(s, 0, 7);
 
     _ = c.lua_pushstring(s, "Battery");
     c.lua_setfield(s, -2, "__block_type");
@@ -966,6 +971,9 @@ fn luaBarBlockBattery(state: ?*c.lua_State) callconv(.c) c_int {
     _ = c.lua_getfield(s, 1, "underline");
     c.lua_setfield(s, -2, "underline");
 
+    _ = c.lua_getfield(s, 1, "click");
+    c.lua_setfield(s, -2, "click");
+
     c.lua_createtable(s, 0, 4);
     _ = c.lua_getfield(s, 1, "charging");
     c.lua_setfield(s, -2, "charging");
@@ -981,7 +989,7 @@ fn luaBarBlockBattery(state: ?*c.lua_State) callconv(.c) c_int {
 }
 
 fn createBlockTable(state: *c.lua_State, block_type: [*:0]const u8, arg: ?[]const u8) void {
-    c.lua_createtable(state, 0, 6);
+    c.lua_createtable(state, 0, 7);
 
     _ = c.lua_pushstring(state, block_type);
     c.lua_setfield(state, -2, "__block_type");
@@ -997,6 +1005,9 @@ fn createBlockTable(state: *c.lua_State, block_type: [*:0]const u8, arg: ?[]cons
 
     _ = c.lua_getfield(state, 1, "underline");
     c.lua_setfield(state, -2, "underline");
+
+    _ = c.lua_getfield(state, 1, "click");
+    c.lua_setfield(state, -2, "click");
 
     if (arg) |a| {
         var buf: [256]u8 = undefined;
@@ -1210,6 +1221,26 @@ fn dupeLuaString(state: *c.lua_State, idx: c_int) ?[]const u8 {
     const arena_allocator = cfg.string_arena.allocator();
     const duped = arena_allocator.dupe(u8, lua_str) catch return null;
     return duped;
+}
+
+fn parseClickAction(state: *c.lua_State, idx: c_int) ?config_mod.ClickAction {
+    const lua_type = c.lua_type(state, idx);
+    if (lua_type == c.LUA_TSTRING) {
+        const cmd = dupeLuaString(state, idx) orelse return null;
+        return .{ .command = cmd };
+    } else if (lua_type == c.LUA_TTABLE) {
+        _ = c.lua_getfield(state, idx, "command");
+        const cmd = dupeLuaString(state, -1);
+        c.lua_settop(state, -2);
+        if (cmd == null) return null;
+
+        _ = c.lua_getfield(state, idx, "floating");
+        const floating = c.lua_toboolean(state, -1) != 0;
+        c.lua_settop(state, -2);
+
+        return .{ .command = cmd.?, .floating = floating };
+    }
+    return null;
 }
 
 fn parseColor(state: *c.lua_State, idx: c_int) u32 {

--- a/src/config/lua.zig
+++ b/src/config/lua.zig
@@ -274,6 +274,9 @@ fn registerBarModule(state: *c.lua_State) void {
     c.lua_pushcfunction(state, luaBarSetHideVacantTags);
     c.lua_setfield(state, -2, "set_hide_vacant_tags");
 
+    c.lua_pushcfunction(state, luaBarSetPosition);
+    c.lua_setfield(state, -2, "set_position");
+
     c.lua_createtable(state, 0, 6);
 
     c.lua_pushcfunction(state, luaBarBlockRam);
@@ -751,6 +754,15 @@ fn luaBarSetFont(state: ?*c.lua_State) callconv(.c) c_int {
     const s = state orelse return 0;
     if (dupeLuaString(s, 1)) |font| {
         cfg.font = font;
+    }
+    return 0;
+}
+
+fn luaBarSetPosition(state: ?*c.lua_State) callconv(.c) c_int {
+    const cfg = config orelse return 0;
+    const s = state orelse return 0;
+    if (dupeLuaString(s, 1)) |position| {
+        cfg.bar_position = position;
     }
     return 0;
 }

--- a/src/config/lua.zig
+++ b/src/config/lua.zig
@@ -1046,6 +1046,11 @@ fn luaSetTerminal(state: ?*c.lua_State) callconv(.c) c_int {
 fn luaSetLayout(state: ?*c.lua_State) callconv(.c) c_int {
     const cfg = config orelse return 0;
     const s = state orelse return 0;
+    const name = getStringArg(s, 1) orelse return 0;
+    if (config_mod.Layouts.fromString(name) == null) {
+        std.debug.print("set_layout: unknown layout '{s}'\n", .{name});
+        return 0;
+    }
     if (dupeLuaString(s, 1)) |layout| {
         cfg.layout = layout;
     }

--- a/src/config/lua.zig
+++ b/src/config/lua.zig
@@ -330,6 +330,9 @@ fn registerMiscFunctions(state: *c.lua_State) void {
     c.lua_pushcfunction(state, luaToggleGaps);
     c.lua_setfield(state, -2, "toggle_gaps");
 
+    c.lua_pushcfunction(state, luaToggleBar);
+    c.lua_setfield(state, -2, "toggle_bar");
+
     c.lua_pushcfunction(state, luaShowKeybinds);
     c.lua_setfield(state, -2, "show_keybinds");
 
@@ -1131,6 +1134,12 @@ fn luaToggleGaps(state: ?*c.lua_State) callconv(.c) c_int {
     return 1;
 }
 
+fn luaToggleBar(state: ?*c.lua_State) callconv(.c) c_int {
+    const s = state orelse return 0;
+    createActionTable(s, "ToggleBar");
+    return 1;
+}
+
 fn luaShowKeybinds(state: ?*c.lua_State) callconv(.c) c_int {
     const s = state orelse return 0;
     createActionTable(s, "ShowKeybinds");
@@ -1281,6 +1290,7 @@ fn parseAction(name: []const u8) ?Action {
         .{ "ToggleFloating", Action.toggle_floating },
         .{ "ToggleFullScreen", Action.toggle_fullscreen },
         .{ "ToggleGaps", Action.toggle_gaps },
+        .{ "ToggleBar", Action.toggle_bar },
         .{ "CycleLayout", Action.cycle_layout },
         .{ "ChangeLayout", Action.set_layout },
         .{ "ViewTag", Action.view_tag },

--- a/src/config/lua.zig
+++ b/src/config/lua.zig
@@ -344,6 +344,9 @@ fn registerMiscFunctions(state: *c.lua_State) void {
 
     c.lua_pushcfunction(state, luaSetTagLayout);
     c.lua_setfield(state, -2, "set_tag_layout");
+
+    c.lua_pushcfunction(state, luaSetFloatingPosition);
+    c.lua_setfield(state, -2, "set_floating_position");
 }
 
 fn createActionTable(state: *c.lua_State, action_name: [*:0]const u8) void {
@@ -1018,6 +1021,17 @@ fn createBlockTable(state: *c.lua_State, block_type: [*:0]const u8, arg: ?[]cons
             c.lua_setfield(state, -2, "__arg");
         }
     }
+}
+
+fn luaSetFloatingPosition(state: ?*c.lua_State) callconv(.c) c_int {
+    const cfg = config orelse return 0;
+    const s = state orelse return 0;
+    if (getLuaString(s, 1)) |name| {
+        if (config_mod.FloatingPosition.fromString(name)) |pos| {
+            cfg.floating_position = pos;
+        }
+    }
+    return 0;
 }
 
 fn luaSetTerminal(state: ?*c.lua_State) callconv(.c) c_int {

--- a/src/config/lua.zig
+++ b/src/config/lua.zig
@@ -1092,6 +1092,7 @@ fn luaSetLayoutSymbol(state: ?*c.lua_State) callconv(.c) c_int {
         .{ "monocle", &cfg.layout_monocle_symbol },
         .{ "scrolling", &cfg.layout_scrolling_symbol },
         .{ "scroll", &cfg.layout_scrolling_symbol },
+        .{ "grid", &cfg.layout_grid_symbol },
     };
 
     inline for (layout_map) |entry| {

--- a/src/overlay.zig
+++ b/src/overlay.zig
@@ -172,7 +172,7 @@ pub const KeybindOverlay = struct {
         if (self.display) |display| {
             _ = xlib.XUngrabKeyboard(display, xlib.CurrentTime);
             if (self.window != 0) {
-                _ = xlib.c.XUnmapWindow(display, self.window);
+                _ = xlib.XUnmapWindow(display, self.window);
             }
         }
         self.visible = false;

--- a/src/wm/actions.zig
+++ b/src/wm/actions.zig
@@ -358,7 +358,7 @@ pub fn cycleLayout(wm: *WindowManager) void {
 pub fn setLayout(layout_name: ?[]const u8, wm: *WindowManager) void {
     const monitor = wm.selected_monitor orelse return;
     const name = layout_name orelse return;
-    const new_lt: u32 = if (std.meta.stringToEnum(config_mod.Layouts, name)) |value|
+    const new_lt: u32 = if (config_mod.Layouts.fromString(name)) |value|
         @intFromEnum(value)
     else {
         std.debug.print("set_layout: unknown layout '{s}'\n", .{name});

--- a/src/wm/actions.zig
+++ b/src/wm/actions.zig
@@ -342,15 +342,15 @@ pub fn setmfact(delta: f32, wm: *WindowManager) void {
 
 pub fn cycleLayout(wm: *WindowManager) void {
     const monitor = wm.selected_monitor orelse return;
-    const new_lt = (monitor.sel_lt + 1) % 5;
+    const new_lt = (monitor.sel_lt + 1) % @as(u32, @intCast(std.meta.fields(config_mod.Layouts).len));
     monitor.sel_lt = new_lt;
     monitor.pertag.sellts[monitor.pertag.curtag] = new_lt;
-    if (new_lt != 3) {
+    if (new_lt != @intFromEnum(config_mod.Layouts.scrolling)) {
         monitor.scroll_offset = 0;
     }
     core.arrange(monitor, wm);
     wm.invalidateBars();
-    if (monitor.lt[monitor.sel_lt]) |layout| {
+    if (monitor.lt[@as(usize, monitor.sel_lt)]) |layout| {
         std.debug.print("cycle_layout: {s}\n", .{layout.symbol});
     }
 }
@@ -358,44 +358,35 @@ pub fn cycleLayout(wm: *WindowManager) void {
 pub fn setLayout(layout_name: ?[]const u8, wm: *WindowManager) void {
     const monitor = wm.selected_monitor orelse return;
     const name = layout_name orelse return;
-
-    const new_lt: u32 = if (std.mem.eql(u8, name, "tiling") or std.mem.eql(u8, name, "[]="))
-        0
-    else if (std.mem.eql(u8, name, "monocle") or std.mem.eql(u8, name, "[M]"))
-        1
-    else if (std.mem.eql(u8, name, "floating") or std.mem.eql(u8, name, "><>"))
-        2
-    else if (std.mem.eql(u8, name, "scrolling") or std.mem.eql(u8, name, "[S]"))
-        3
-    else if (std.mem.eql(u8, name, "grid") or std.mem.eql(u8, name, "[#]"))
-        4
+    const new_lt: u32 = if (std.meta.stringToEnum(config_mod.Layouts, name)) |value|
+        @intFromEnum(value)
     else {
         std.debug.print("set_layout: unknown layout '{s}'\n", .{name});
         return;
     };
-
     monitor.sel_lt = new_lt;
     monitor.pertag.sellts[monitor.pertag.curtag] = new_lt;
-    if (new_lt != 3) {
+    if (new_lt != @intFromEnum(config_mod.Layouts.scrolling)) {
         monitor.scroll_offset = 0;
     }
     core.arrange(monitor, wm);
     wm.invalidateBars();
-    if (monitor.lt[monitor.sel_lt]) |layout| {
+    if (monitor.lt[@as(usize, monitor.sel_lt)]) |layout| {
         std.debug.print("set_layout: {s}\n", .{layout.symbol});
     }
 }
 
 pub fn setLayoutIndex(index: u32, wm: *WindowManager) void {
     const monitor = wm.selected_monitor orelse return;
-    monitor.sel_lt = index;
-    monitor.pertag.sellts[monitor.pertag.curtag] = index;
-    if (index != 3) {
+    const lt_index = index % @as(u32, @intCast(std.meta.fields(config_mod.Layouts).len));
+    monitor.sel_lt = lt_index;
+    monitor.pertag.sellts[monitor.pertag.curtag] = lt_index;
+    if (lt_index != @intFromEnum(config_mod.Layouts.scrolling)) {
         monitor.scroll_offset = 0;
     }
     core.arrange(monitor, wm);
     wm.invalidateBars();
-    if (monitor.lt[monitor.sel_lt]) |layout| {
+    if (monitor.lt[@as(usize, monitor.sel_lt)]) |layout| {
         std.debug.print("set_layout_index: {s}\n", .{layout.symbol});
     }
 }

--- a/src/wm/actions.zig
+++ b/src/wm/actions.zig
@@ -6,6 +6,7 @@ const lua = @import("../config/lua.zig");
 const core = @import("core.zig");
 const tiling = @import("../layouts/tiling.zig");
 const monitor_mod = @import("../monitor.zig");
+const bar_mod = @import("../bar/bar.zig");
 const wm_mod = @import("wm.zig");
 const xlib = @import("../x11/xlib.zig");
 
@@ -148,6 +149,12 @@ pub fn toggleView(tag_mask: u32, wm: *WindowManager) void {
         monitor.mfact = monitor.pertag.mfacts[monitor.pertag.curtag];
         monitor.sel_lt = monitor.pertag.sellts[monitor.pertag.curtag];
 
+        const new_show_bar = monitor.pertag.showbars[monitor.pertag.curtag];
+        if (new_show_bar != monitor.show_bar) {
+            monitor.show_bar = new_show_bar;
+            updateBarVisibility(monitor, wm);
+        }
+
         core.focusTopClient(monitor, wm);
         core.arrange(monitor, wm);
         wm.invalidateBars();
@@ -180,6 +187,35 @@ pub fn toggleGaps(wm: *WindowManager) void {
         monitor.gap_outer_v = 0;
     }
     core.arrange(monitor, wm);
+}
+
+pub fn updateBarVisibility(monitor: *Monitor, wm: *WindowManager) void {
+    const bar = bar_mod.windowToBar(wm.bars, monitor.bar_win) orelse return;
+
+    if (monitor.show_bar) {
+        _ = xlib.XMapWindow(wm.display.handle, bar.window);
+        monitor.win_h -= bar.height;
+        if (std.mem.eql(u8, wm.config.bar_position, "top")) {
+            monitor.mon_y += bar.height;
+        }
+    } else {
+        _ = xlib.c.XUnmapWindow(wm.display.handle, bar.window);
+        monitor.win_h += bar.height;
+        if (std.mem.eql(u8, wm.config.bar_position, "top")) {
+            monitor.mon_y -= bar.height;
+        }
+    }
+}
+
+pub fn toggleBar(wm: *WindowManager) void {
+    const monitor = wm.selected_monitor orelse return;
+    monitor.show_bar = !monitor.show_bar;
+    monitor.pertag.showbars[monitor.pertag.curtag] = monitor.show_bar;
+
+    updateBarVisibility(monitor, wm);
+
+    core.arrange(monitor, wm);
+    wm.invalidateBars();
 }
 
 pub fn killFocused(wm: *WindowManager) void {
@@ -680,6 +716,7 @@ pub fn executeAction(action: config_mod.Action, int_arg: i32, str_arg: ?[]const 
         .toggle_floating => toggleFloating(wm),
         .toggle_fullscreen => toggleFullscreen(wm),
         .toggle_gaps => toggleGaps(wm),
+        .toggle_bar => toggleBar(wm),
         .cycle_layout => cycleLayout(wm),
         .set_layout => setLayout(str_arg, wm),
         .set_layout_tiling => setLayoutIndex(0, wm),

--- a/src/wm/actions.zig
+++ b/src/wm/actions.zig
@@ -196,13 +196,13 @@ pub fn updateBarVisibility(monitor: *Monitor, wm: *WindowManager) void {
         _ = xlib.XMapWindow(wm.display.handle, bar.window);
         monitor.win_h -= bar.height;
         if (std.mem.eql(u8, wm.config.bar_position, "top")) {
-            monitor.mon_y += bar.height;
+            monitor.win_y += bar.height;
         }
     } else {
-        _ = xlib.c.XUnmapWindow(wm.display.handle, bar.window);
+        _ = xlib.XUnmapWindow(wm.display.handle, bar.window);
         monitor.win_h += bar.height;
         if (std.mem.eql(u8, wm.config.bar_position, "top")) {
-            monitor.mon_y -= bar.height;
+            monitor.win_y -= bar.height;
         }
     }
 }

--- a/src/wm/core.zig
+++ b/src/wm/core.zig
@@ -40,7 +40,14 @@ pub fn manage(win: xlib.Window, window_attrs: *xlib.XWindowAttributes, wm: *Wind
 
     if (client.monitor == null) {
         client.monitor = wm.selected_monitor;
-        applyRules(client, wm);
+        if (wm.next_spawn_bypass_rules) {
+            if (client.monitor) |monitor| {
+                client.tags = monitor.tagset[monitor.sel_tags];
+            }
+            wm.next_spawn_bypass_rules = false;
+        } else {
+            applyRules(client, wm);
+        }
     }
 
     if (wm.next_spawn_floating) {

--- a/src/wm/core.zig
+++ b/src/wm/core.zig
@@ -41,6 +41,11 @@ pub fn manage(win: xlib.Window, window_attrs: *xlib.XWindowAttributes, wm: *Wind
         applyRules(client, wm);
     }
 
+    if (wm.next_spawn_floating) {
+        client.is_floating = true;
+        wm.next_spawn_floating = false;
+    }
+
     const monitor = client.monitor orelse return;
 
     if (client.x + client.width > monitor.win_x + monitor.win_w) {

--- a/src/wm/core.zig
+++ b/src/wm/core.zig
@@ -6,6 +6,8 @@ const tiling = @import("../layouts/tiling.zig");
 const scrolling = @import("../layouts/scrolling.zig");
 const window_manager = @import("wm.zig");
 
+const config_mod = @import("../config/config.zig");
+
 const Client = client_mod.Client;
 const Monitor = monitor_mod.Monitor;
 const WindowManager = window_manager.WindowManager;
@@ -77,6 +79,7 @@ pub fn manage(win: xlib.Window, window_attrs: *xlib.XWindowAttributes, wm: *Wind
         client.old_state = client.is_floating;
     }
     if (client.is_floating) {
+        positionFloating(client, monitor, wm.config.floating_position);
         _ = xlib.XRaiseWindow(wm.display.handle, client.window);
     }
 
@@ -435,6 +438,22 @@ pub fn scrollToWindow(client: *Client, animate: bool, wm: *WindowManager) void {
         monitor.scroll_offset = target;
         arrange(monitor, wm);
     }
+}
+
+fn positionFloating(client: *Client, monitor: *Monitor, pos: config_mod.FloatingPosition) void {
+    const bw = 2 * client.border_width;
+    const x: i32 = switch (pos) {
+        .top_left, .center_left, .bottom_left => monitor.win_x,
+        .top_center, .center, .bottom_center => monitor.win_x + @divTrunc(monitor.win_w - client.width - bw, 2),
+        .top_right, .center_right, .bottom_right => monitor.win_x + monitor.win_w - client.width - bw,
+    };
+    const y: i32 = switch (pos) {
+        .top_left, .top_center, .top_right => monitor.win_y,
+        .center_left, .center, .center_right => monitor.win_y + @divTrunc(monitor.win_h - client.height - bw, 2),
+        .bottom_left, .bottom_center, .bottom_right => monitor.win_y + monitor.win_h - client.height - bw,
+    };
+    client.x = x;
+    client.y = y;
 }
 
 pub fn applyRules(client: *Client, wm: *WindowManager) void {

--- a/src/wm/core.zig
+++ b/src/wm/core.zig
@@ -729,6 +729,12 @@ pub fn view(tag_mask: u32, wm: *WindowManager) void {
     monitor.mfact = monitor.pertag.mfacts[monitor.pertag.curtag];
     monitor.sel_lt = monitor.pertag.sellts[monitor.pertag.curtag];
 
+    const new_show_bar = monitor.pertag.showbars[monitor.pertag.curtag];
+    if (new_show_bar != monitor.show_bar) {
+        monitor.show_bar = new_show_bar;
+        window_manager.actions.updateBarVisibility(monitor, wm);
+    }
+
     focusTopClient(monitor, wm);
     arrange(monitor, wm);
     wm.invalidateBars();

--- a/src/wm/handlers.zig
+++ b/src/wm/handlers.zig
@@ -211,6 +211,7 @@ fn handleButtonPress(event: *xlib.XButtonEvent, wm: *WindowManager) void {
             core.view(tag_mask, wm);
         } else if (bar.handleBlockClick(event.x)) |click_action| {
             wm.next_spawn_floating = click_action.floating;
+            wm.next_spawn_bypass_rules = click_action.bypass_rules;
             actions.spawnCommand(wm, click_action.command);
         }
         return;

--- a/src/wm/handlers.zig
+++ b/src/wm/handlers.zig
@@ -209,6 +209,9 @@ fn handleButtonPress(event: *xlib.XButtonEvent, wm: *WindowManager) void {
         if (clicked_tag) |tag_index| {
             const tag_mask: u32 = @as(u32, 1) << @intCast(tag_index);
             core.view(tag_mask, wm);
+        } else if (bar.handleBlockClick(event.x)) |click_action| {
+            wm.next_spawn_floating = click_action.floating;
+            actions.spawnCommand(wm, click_action.command);
         }
         return;
     }

--- a/src/wm/wm.zig
+++ b/src/wm/wm.zig
@@ -85,6 +85,7 @@ pub const WindowManager = struct {
 
     running: bool,
     next_spawn_floating: bool = false,
+    next_spawn_bypass_rules: bool = false,
     last_motion_monitor: ?*Monitor,
 
     /// Initialises the window manager

--- a/src/wm/wm.zig
+++ b/src/wm/wm.zig
@@ -181,7 +181,7 @@ pub const WindowManager = struct {
             slot.* = layout;
         }
 
-        if (std.meta.stringToEnum(config_mod.Layouts, self.config.layout)) |value| {
+        if (config_mod.Layouts.fromString(self.config.layout)) |value| {
             mon.sel_lt = @intFromEnum(value);
         }
 
@@ -190,6 +190,14 @@ pub const WindowManager = struct {
                 mon.pertag.ltidxs[i][j] = mon.lt[j];
             }
             mon.pertag.sellts[i] = mon.sel_lt;
+        }
+
+        for (self.config.tag_layouts, 0..) |maybe_layout, i| {
+            if (maybe_layout) |layout_name| {
+                if (config_mod.Layouts.fromString(layout_name)) |value| {
+                    mon.pertag.sellts[i + 1] = @intFromEnum(value);
+                }
+            }
         }
 
         self.initMonitorGaps(mon);

--- a/src/wm/wm.zig
+++ b/src/wm/wm.zig
@@ -158,48 +158,57 @@ pub const WindowManager = struct {
         self.config.deinit();
     }
 
+    const layouts = [_]*const monitor_mod.Layout{
+        &tiling.layout,
+        &monocle.layout,
+        &floating.layout,
+        &scrolling.layout,
+        &grid.layout,
+    };
+
+    fn initMonitor(self: *WindowManager, mon: *Monitor, num: usize, x: i16, y: i16, w: c_int, h: c_int) void {
+        mon.num = @intCast(num);
+        mon.mon_x = x;
+        mon.mon_y = y;
+        mon.mon_w = w;
+        mon.mon_h = h;
+        mon.win_x = x;
+        mon.win_y = y;
+        mon.win_w = w;
+        mon.win_h = h;
+
+        for (&mon.lt, layouts) |*slot, layout| {
+            slot.* = layout;
+        }
+
+        if (std.meta.stringToEnum(config_mod.Layouts, self.config.layout)) |value| {
+            mon.sel_lt = @intFromEnum(value);
+        }
+
+        for (0..10) |i| {
+            for (0..layouts.len) |j| {
+                mon.pertag.ltidxs[i][j] = mon.lt[j];
+            }
+            mon.pertag.sellts[i] = mon.sel_lt;
+        }
+
+        self.initMonitorGaps(mon);
+    }
+
     fn setupMonitors(self: *WindowManager) void {
         if (xlib.XineramaIsActive(self.display.handle) != 0) {
             var screen_count: c_int = 0;
             const screens = xlib.XineramaQueryScreens(self.display.handle, &screen_count);
+            defer if (screens != null) {
+                _ = xlib.XFree(@ptrCast(screens));
+            };
 
             if (screen_count > 0 and screens != null) {
                 var prev_monitor: ?*Monitor = null;
-                var index: usize = 0;
-
-                while (index < @as(usize, @intCast(screen_count))) : (index += 1) {
+                for (0..@as(usize, @intCast(screen_count))) |index| {
                     const screen = screens[index];
                     const mon = monitor_mod.create(self.allocator) orelse continue;
-
-                    mon.num = @intCast(index);
-                    mon.mon_x = screen.x_org;
-                    mon.mon_y = screen.y_org;
-                    mon.mon_w = screen.width;
-                    mon.mon_h = screen.height;
-                    mon.win_x = screen.x_org;
-                    mon.win_y = screen.y_org;
-                    mon.win_w = screen.width;
-                    mon.win_h = screen.height;
-
-                    mon.lt[@intFromEnum(config_mod.Layouts.tiling)] = &tiling.layout;
-                    mon.lt[@intFromEnum(config_mod.Layouts.monocle)] = &monocle.layout;
-                    mon.lt[@intFromEnum(config_mod.Layouts.floating)] = &floating.layout;
-                    mon.lt[@intFromEnum(config_mod.Layouts.scrolling)] = &scrolling.layout;
-                    mon.lt[@intFromEnum(config_mod.Layouts.grid)] = &grid.layout;
-
-                    if (std.meta.stringToEnum(config_mod.Layouts, self.config.layout)) |value| {
-                        mon.sel_lt = @intFromEnum(value);
-                    }
-
-                    for (0..10) |i| {
-                        mon.pertag.ltidxs[i][0] = mon.lt[0];
-                        mon.pertag.ltidxs[i][1] = mon.lt[1];
-                        mon.pertag.ltidxs[i][2] = mon.lt[2];
-                        mon.pertag.ltidxs[i][3] = mon.lt[3];
-                        mon.pertag.ltidxs[i][4] = mon.lt[4];
-                    }
-
-                    self.initMonitorGaps(mon);
+                    self.initMonitor(mon, index, screen.x_org, screen.y_org, screen.width, screen.height);
 
                     if (prev_monitor) |prev| {
                         prev.next = mon;
@@ -209,43 +218,12 @@ pub const WindowManager = struct {
                     }
                     prev_monitor = mon;
                 }
-
-                _ = xlib.XFree(@ptrCast(screens));
             }
         }
 
-        // Fallback: single monitor covering the full screen.
         if (self.monitors == null) {
             const mon = monitor_mod.create(self.allocator) orelse return;
-            mon.num = 0;
-            mon.mon_x = 0;
-            mon.mon_y = 0;
-            mon.mon_w = self.display.screenWidth();
-            mon.mon_h = self.display.screenHeight();
-            mon.win_x = 0;
-            mon.win_y = 0;
-            mon.win_w = mon.mon_w;
-            mon.win_h = mon.mon_h;
-
-            mon.lt[@intFromEnum(config_mod.Layouts.tiling)] = &tiling.layout;
-            mon.lt[@intFromEnum(config_mod.Layouts.monocle)] = &monocle.layout;
-            mon.lt[@intFromEnum(config_mod.Layouts.floating)] = &floating.layout;
-            mon.lt[@intFromEnum(config_mod.Layouts.scrolling)] = &scrolling.layout;
-            mon.lt[@intFromEnum(config_mod.Layouts.grid)] = &grid.layout;
-
-            if (std.meta.stringToEnum(config_mod.Layouts, self.config.layout)) |value| {
-                mon.sel_lt = @intFromEnum(value);
-            }
-
-            for (0..10) |i| {
-                mon.pertag.ltidxs[i][0] = mon.lt[0];
-                mon.pertag.ltidxs[i][1] = mon.lt[1];
-                mon.pertag.ltidxs[i][2] = mon.lt[2];
-                mon.pertag.ltidxs[i][3] = mon.lt[3];
-                mon.pertag.ltidxs[i][4] = mon.lt[4];
-            }
-
-            self.initMonitorGaps(mon);
+            self.initMonitor(mon, 0, 0, 0, self.display.screenWidth(), self.display.screenHeight());
             self.monitors = mon;
             self.selected_monitor = mon;
         }

--- a/src/wm/wm.zig
+++ b/src/wm/wm.zig
@@ -180,11 +180,16 @@ pub const WindowManager = struct {
                     mon.win_y = screen.y_org;
                     mon.win_w = screen.width;
                     mon.win_h = screen.height;
-                    mon.lt[0] = &tiling.layout;
-                    mon.lt[1] = &monocle.layout;
-                    mon.lt[2] = &floating.layout;
-                    mon.lt[3] = &scrolling.layout;
-                    mon.lt[4] = &grid.layout;
+
+                    mon.lt[@intFromEnum(config_mod.Layouts.tiling)] = &tiling.layout;
+                    mon.lt[@intFromEnum(config_mod.Layouts.monocle)] = &monocle.layout;
+                    mon.lt[@intFromEnum(config_mod.Layouts.floating)] = &floating.layout;
+                    mon.lt[@intFromEnum(config_mod.Layouts.scrolling)] = &scrolling.layout;
+                    mon.lt[@intFromEnum(config_mod.Layouts.grid)] = &grid.layout;
+
+                    if (std.meta.stringToEnum(config_mod.Layouts, self.config.layout)) |value| {
+                        mon.sel_lt = @intFromEnum(value);
+                    }
 
                     for (0..10) |i| {
                         mon.pertag.ltidxs[i][0] = mon.lt[0];
@@ -221,11 +226,16 @@ pub const WindowManager = struct {
             mon.win_y = 0;
             mon.win_w = mon.mon_w;
             mon.win_h = mon.mon_h;
-            mon.lt[0] = &tiling.layout;
-            mon.lt[1] = &monocle.layout;
-            mon.lt[2] = &floating.layout;
-            mon.lt[3] = &scrolling.layout;
-            mon.lt[4] = &grid.layout;
+
+            mon.lt[@intFromEnum(config_mod.Layouts.tiling)] = &tiling.layout;
+            mon.lt[@intFromEnum(config_mod.Layouts.monocle)] = &monocle.layout;
+            mon.lt[@intFromEnum(config_mod.Layouts.floating)] = &floating.layout;
+            mon.lt[@intFromEnum(config_mod.Layouts.scrolling)] = &scrolling.layout;
+            mon.lt[@intFromEnum(config_mod.Layouts.grid)] = &grid.layout;
+
+            if (std.meta.stringToEnum(config_mod.Layouts, self.config.layout)) |value| {
+                mon.sel_lt = @intFromEnum(value);
+            }
 
             for (0..10) |i| {
                 mon.pertag.ltidxs[i][0] = mon.lt[0];

--- a/src/wm/wm.zig
+++ b/src/wm/wm.zig
@@ -84,6 +84,7 @@ pub const WindowManager = struct {
     animation_config: animations.AnimationConfig,
 
     running: bool,
+    next_spawn_floating: bool = false,
     last_motion_monitor: ?*Monitor,
 
     /// Initialises the window manager
@@ -553,7 +554,7 @@ pub const WindowManager = struct {
 
 /// Converts a config block description into a live status bar block.
 pub fn configBlockToBarBlock(cfg: config_mod.Block) blocks_mod.Block {
-    return switch (cfg.block_type) {
+    var block = switch (cfg.block_type) {
         .static => blocks_mod.Block.initStatic(cfg.format, cfg.color, cfg.underline),
         .datetime => blocks_mod.Block.initDatetime(
             cfg.format,
@@ -587,4 +588,6 @@ pub fn configBlockToBarBlock(cfg: config_mod.Block) blocks_mod.Block {
             cfg.underline,
         ),
     };
+    block.click = cfg.click;
+    return block;
 }

--- a/src/x11/xlib.zig
+++ b/src/x11/xlib.zig
@@ -42,6 +42,7 @@ pub const XQueryTree = c.XQueryTree;
 pub const XFree = c.XFree;
 pub const XGetWindowAttributes = c.XGetWindowAttributes;
 pub const XMapWindow = c.XMapWindow;
+pub const XUnmapWindow = c.XUnmapWindow;
 pub const XConfigureWindow = c.XConfigureWindow;
 pub const XSetInputFocus = c.XSetInputFocus;
 pub const XRaiseWindow = c.XRaiseWindow;

--- a/templates/config.lua
+++ b/templates/config.lua
@@ -114,6 +114,10 @@ oxwm.set_layout_symbol("tiling", "[T]")
 oxwm.set_layout_symbol("normie", "[F]")
 oxwm.set_layout_symbol("tabbed", "[=]")
 
+-- Set default layout of specific tag (tag_index, layout_name)
+-- Unset value uses oxwm.set_layout value
+-- oxwm.set_tag_layout(1, "grid")
+
 -------------------------------------------------------------------------------
 -- Appearance
 -------------------------------------------------------------------------------

--- a/templates/config.lua
+++ b/templates/config.lua
@@ -133,6 +133,10 @@ oxwm.border.set_focused_color(colors.blue)
 -- Color of unfocused window borders
 oxwm.border.set_unfocused_color(colors.grey)
 
+-- Where floating windows spawn: "top-left", "top-center", "top-right",
+-- "center-left", "center", "center-right", "bottom-left", "bottom-center", "bottom-right"
+oxwm.set_floating_position("center")
+
 -- Smart Enabled = No border if 1 window
 oxwm.gaps.set_smart(enabled)
 -- Inner gaps (horizontal, vertical) in pixels

--- a/templates/config.lua
+++ b/templates/config.lua
@@ -92,6 +92,9 @@ local blocks = {
         interval = 30,
         color = colors.green,
         underline = true,
+        -- click: run a command when the block is clicked
+        -- click = "alacritty -e btop",
+        -- click = { command = "bluetui", floating = true },
     }),
 };
 

--- a/templates/config.lua
+++ b/templates/config.lua
@@ -161,6 +161,9 @@ oxwm.rule.add({ instance = "gimp", floating = true })
 -- Font configuration
 oxwm.bar.set_font(bar_font)
 
+-- Position configuration (top/bottom, top is default)
+-- oxwm.bar.set_position("bottom")
+
 -- Set your blocks here (defined above)
 oxwm.bar.set_blocks(blocks)
 

--- a/templates/config.lua
+++ b/templates/config.lua
@@ -102,6 +102,9 @@ oxwm.set_terminal(terminal)
 oxwm.set_modkey(modkey) -- This is for Mod + mouse binds, such as drag/resize
 oxwm.set_tags(tags)
 
+-- Set default layout (tiling by default)
+-- oxwm.set_layout("tiling")
+
 -------------------------------------------------------------------------------
 -- Layouts
 -------------------------------------------------------------------------------

--- a/templates/config.lua
+++ b/templates/config.lua
@@ -230,6 +230,8 @@ oxwm.key.bind({ modkey }, "P", oxwm.inc_num_master(-1))
 
 -- Gaps toggle
 oxwm.key.bind({ modkey }, "A", oxwm.toggle_gaps())
+-- Bar toggle
+oxwm.key.bind({ modkey }, "B", oxwm.toggle_bar())
 
 -- Window manager controls
 oxwm.key.bind({ modkey, "Shift" }, "Q", oxwm.quit())

--- a/templates/oxwm.lua
+++ b/templates/oxwm.lua
@@ -46,6 +46,23 @@ function oxwm.auto_tile(enabled) end
 ---@param symbol string Symbol to display (e.g., "[T]", "[F]", "[=]")
 function oxwm.set_layout_symbol(name, symbol) end
 
+---Set default layout for all tags
+---@param name string Layout name ("tiling", "floating", "scrolling", "grid", "monocle", or aliases: "tile", "float", "scroll", "normie")
+function oxwm.set_layout(name) end
+
+---Set default layout for a specific tag
+---@param tag integer Tag index (1-9)
+---@param name string Layout name ("tiling", "floating", "scrolling", "grid", "monocle", or aliases)
+function oxwm.set_tag_layout(tag, name) end
+
+---Set floating window spawn position
+---@param position string Position ("center", "top-left", "top-right", "bottom-left", "bottom-right", "top-center", "bottom-center", "center-left", "center-right", or underscore variants)
+function oxwm.set_floating_position(position) end
+
+---Toggle the status bar visibility
+---@return table Action table for keybinding
+function oxwm.toggle_bar() end
+
 ---Window rule module
 ---@class oxwm.rule
 oxwm.rule = {}
@@ -256,6 +273,10 @@ oxwm.bar = {}
 ---@param font string Font string (e.g., "monospace:style=Bold:size=10")
 function oxwm.bar.set_font(font) end
 
+---Set status bar position
+---@param position string Bar position ("top" or "bottom")
+function oxwm.bar.set_position(position) end
+
 ---DEPRECATED: Add a status bar block (use oxwm.bar.set_blocks with block constructors instead)
 ---@deprecated
 ---@param format string Format string with {} placeholders
@@ -275,27 +296,27 @@ function oxwm.bar.set_blocks(blocks) end
 oxwm.bar.block = {}
 
 ---Create a RAM usage block
----@param config {format: string, interval: integer, color: string|integer, underline: boolean} Block configuration
+---@param config {format: string, interval: integer, color: string|integer, underline: boolean, click: string|{command: string, floating: boolean?, bypass_rules: boolean?}?} Block configuration
 ---@return table Block configuration
 function oxwm.bar.block.ram(config) end
 
 ---Create a date/time block
----@param config {format: string, date_format: string, interval: integer, color: string|integer, underline: boolean} Block configuration (format is display template with {}, date_format is strftime format)
+---@param config {format: string, date_format: string, interval: integer, color: string|integer, underline: boolean, click: string|{command: string, floating: boolean?, bypass_rules: boolean?}?} Block configuration (format is display template with {}, date_format is strftime format)
 ---@return table Block configuration
 function oxwm.bar.block.datetime(config) end
 
 ---Create a shell command block
----@param config {format: string, command: string, interval: integer, color: string|integer, underline: boolean} Block configuration
+---@param config {format: string, command: string, interval: integer, color: string|integer, underline: boolean, click: string|{command: string, floating: boolean?, bypass_rules: boolean?}?} Block configuration
 ---@return table Block configuration
 function oxwm.bar.block.shell(config) end
 
 ---Create a static text block
----@param config {format: string, text: string, interval: integer, color: string|integer, underline: boolean} Block configuration
+---@param config {format: string, text: string, interval: integer, color: string|integer, underline: boolean, click: string|{command: string, floating: boolean?, bypass_rules: boolean?}?} Block configuration
 ---@return table Block configuration
 function oxwm.bar.block.static(config) end
 
 ---Create a battery status block
----@param config {format: string, charging: string, discharging: string, full: string, interval: integer, color: string|integer, underline: boolean, battery_name: string} Block configuration
+---@param config {format: string, charging: string, discharging: string, full: string, interval: integer, color: string|integer, underline: boolean, battery_name: string, click: string|{command: string, floating: boolean?, bypass_rules: boolean?}?} Block configuration
 ---@return table Block configuration
 function oxwm.bar.block.battery(config) end
 


### PR DESCRIPTION
Implements #137, #135, #121, #131, #94

## Features

### Default layout configuration (#137)
Set a default layout in `config.lua`:
```lua
oxwm.set_layout("scrolling")
```

### Per-tag default layouts (#121)
Set a different default layout for specific tags:
```lua
-- tag_index (1-9), layout_name
oxwm.set_tag_layout(1, "grid")
```
Unset tags fall back to the global `oxwm.set_layout` value.

### Bar position (#135)
Configure the bar position (top or bottom):
```lua
-- "top" (default) or "bottom"
oxwm.bar.set_position("bottom")
```

### Toggle bar (#131)
Show / hide the bar (per tag)
```lua
oxwm.key.bind({ modkey }, "B", oxwm.toggle_bar())
```

### Floating position (# 94)
Set a default position for floating windows
```lua
oxwm.set_floating_position("center")
```

### Click handler for blocks
Add a click handler for block to run cmd or spawn floating windows
```lua
    oxwm.bar.block.shell({
        format = "{}",
        command = widgets_folder.."audio_widget.sh --icon",
        interval = 5,
        color = colors.lavender,
        underline = true,
        click = {
            command = "ghostty -e pulsemixer",
            floating = true,
            bypass_rules = true, -- Open the window on the current tag instead of being moved by rules 
        }
    }),
```

## Bug fixes

- **Missing grid layout symbol**: Grid layout now has a proper configurable symbol (`layout_grid_symbol`, defaults to `[#]`) instead of being hardcoded.

## Developer side

- Added `Layouts.fromString()` helper on the `Layouts` enum, centralizing layout name resolution (including aliases like `"tile"`, `"float"`, `"scroll"`, `"normie"`):
```zig
pub const Layouts = enum(u32) {
    tiling,
    monocle,
    floating,
    scrolling,
    grid,

    pub fn fromString(name: []const u8) ?Layouts { ... }
};
```
- Refactored `getLayoutSymbol` and `luaSetLayoutSymbol` to use enum-based switches instead of hardcoded integers/inline maps.
- Added `tag_layouts: [9]?[]const u8` and `bar_position: []const u8` to `Config`.

## Documentation

Documentation has been updated accordingly and a merge request has been prepared.

*I'm still learning zig, what i did might not be following zig to the letter. I'm open to advice*