### PR TITLE
Fix: Fix a vulnerability where the user could bypass the lua sandbox and get an RCE via the config.lua file

### DIFF
--- a/src/config/lua.zig
+++ b/src/config/lua.zig
@@ -19,10 +19,41 @@ var config: ?*Config = null;
 pub fn init(cfg: *Config) bool {
     config = cfg;
     L = c.luaL_newstate();
-    if (L == null) return false;
-    c.luaL_openlibs(L);
+    const state = L orelse return false;
+    openSandboxedLibs(state);
     registerApi();
     return true;
+}
+
+/// Config files run as the user; `luaL_openlibs` would expose `io`,
+/// `os.execute`, `package.loadlib`, `debug`, `require`, and `load`,
+/// making config.lua into an exploitable RCE 
+
+fn openSandboxedLibs(state: *c.lua_State) void {
+    const safe_libs = [_]struct {
+        name: [*:0]const u8,
+        open: c.lua_CFunction,
+    }{
+        .{ .name = "_G", .open = c.luaopen_base },
+        .{ .name = "table", .open = c.luaopen_table },
+        .{ .name = "string", .open = c.luaopen_string },
+        .{ .name = "math", .open = c.luaopen_math },
+        .{ .name = "utf8", .open = c.luaopen_utf8 },
+        .{ .name = "coroutine", .open = c.luaopen_coroutine },
+    };
+    for (safe_libs) |lib| {
+        c.luaL_requiref(state, lib.name, lib.open, 1);
+        c.lua_settop(state, -2);
+    }
+
+    // Any of these turns the sandbox back into an arbitrary-code VM.
+    const banned_globals = [_][*:0]const u8{
+        "dofile", "loadfile", "load", "loadstring", "collectgarbage",
+    };
+    for (banned_globals) |name| {
+        c.lua_pushnil(state);
+        c.lua_setglobal(state, name);
+    }
 }
 
 pub fn deinit() void {
@@ -39,16 +70,6 @@ pub fn loadFile(path: []const u8) bool {
     if (path.len >= path_buf.len) return false;
     @memcpy(path_buf[0..path.len], path);
     path_buf[path.len] = 0;
-
-    if (std.mem.lastIndexOfScalar(u8, path, '/')) |last_slash| {
-        const dir = path[0..last_slash];
-        var setup_buf: [600]u8 = undefined;
-        const setup_code = std.fmt.bufPrintZ(&setup_buf, "package.path = '{s}/?.lua;' .. package.path", .{dir}) catch return false;
-        if (c.luaL_loadstring(state, setup_code.ptr) != 0 or c.lua_pcallk(state, 0, 0, 0, 0, null) != 0) {
-            c.lua_settop(state, -2);
-            return false;
-        }
-    }
 
     if (c.luaL_loadfilex(state, &path_buf, null) != 0) {
         const err = c.lua_tolstring(state, -1, null);


### PR DESCRIPTION
### Description
This PR addresses a problem where an attacker could give a config file for a user with malicious code to run on the config.lua and allow him to get an RCE on the machine of the victim.

### Technical Details
  - **Sandbox (`src/config/lua.zig:openSandboxedLibs`):** Replaced the unconditional `luaL_openlibs(L)` call in `init()` with an explicit allow-list using `luaL_requiref`. Opens only `_G` (base), `table`, `string`, `math`, `utf8`, and `coroutine` — the pure-compute subset. `io`, `os`, `package`, and `debug` are never loaded their globals never exist in the config scope.
  
  - **Dynamic-code loaders:** After opening base, nils `dofile`, `loadfile`, `load`, `loadstring`, and `collectgarbage` via `lua_pushnil` + `lua_setglobal`. Closes every remaining path that could evaluate Lua from a string or file.
  
  - **Removed `package.path` preamble (`src/config/lua.zig:loadFile`):** Deleted the pre-load snippet that set `package.path` by interpolating the config dir into a Lua string and executing it via `luaL_loadstring`. With `package` no longer opened, that snippet would always raise; it was also the single-quote injection sink flagged in the disclosure audit.

### Testing
- Tested inside a archlinux VM 
- Verified that the fix actually works, it does not even create a file with the malicious payload
- Verified that reloading the window manager with the hot reload does not create the payload as well

### Malicous payload for testing

```
 local f = io.open("/tmp/oxwm_rce_canary", "w")
  if f then
    f:write("line1\n")
    f:flush()
    f:write("time=" .. os.date() .. "\n")
    f:flush()
    f:write("home=" .. (os.getenv("HOME") or "?") .. "\n")
    f:close()
  end
  ```
  Placing this on top of a OXWM config would lead to RCE.