### PR TITLE
fix: honor direction arg in FocusStack and MoveStack actions

### DIFF
--- a/src/wm/actions.zig
+++ b/src/wm/actions.zig
@@ -791,9 +791,9 @@ pub fn executeAction(action: config_mod.Action, int_arg: i32, str_arg: ?[]const 
                 }
             }
         },
-        .focus_next => focusstack(1, wm),
+        .focus_next => focusstack(if (int_arg < 0) -1 else 1, wm),
         .focus_prev => focusstack(-1, wm),
-        .move_next => movestack(1, wm),
+        .move_next => movestack(if (int_arg < 0) -1 else 1, wm),
         .move_prev => movestack(-1, wm),
         .resize_master => setmfact(@as(f32, @floatFromInt(int_arg)) / 1000.0, wm),
         .inc_master => incnmaster(1, wm),


### PR DESCRIPTION
The Lua API oxwm.client.focus_stack(dir) and oxwm.client.move_stack(dir) both pass the direction as int_arg, but executeAction hardcoded the direction to +1, ignoring int_arg. As a result, focus_stack(-1) and move_stack(-1) behaved identically to their +1 counterparts, making backward navigation impossible from Lua config.

This affects scrolling layout most visibly: bindings like Super+J for focus_stack(-1) silently moved focus forward instead of back.

Read int_arg in the .focus_next/.move_next branches to pick the direction. focus_prev/move_prev paths remain unchanged.