### PR TITLE
Fix/keybind focus move args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ notes/
 *.md
 
 oxwm-rs/
+zig-pkg/

--- a/src/config/lua.zig
+++ b/src/config/lua.zig
@@ -1347,6 +1347,7 @@ fn parseAction(name: []const u8) ?Action {
         .{ "Restart", Action.restart },
         .{ "ShowKeybinds", Action.show_keybinds },
         .{ "FocusStack", Action.focus_next },
+        .{ "FocusPrev", Action.focus_prev },
         .{ "MoveStack", Action.move_next },
         .{ "ResizeMaster", Action.resize_master },
         .{ "IncMaster", Action.inc_master },

--- a/src/wm/actions.zig
+++ b/src/wm/actions.zig
@@ -791,12 +791,12 @@ pub fn executeAction(action: config_mod.Action, int_arg: i32, str_arg: ?[]const 
                 }
             }
         },
-        .focus_next => focusstack(1, wm),
+        .focus_next => focusstack(if (int_arg != 0) int_arg else 1, wm),
         .focus_prev => focusstack(-1, wm),
-        .move_next => movestack(1, wm),
+        .move_next => movestack(if (int_arg != 0) int_arg else 1, wm),
         .move_prev => movestack(-1, wm),
         .resize_master => setmfact(@as(f32, @floatFromInt(int_arg)) / 1000.0, wm),
-        .inc_master => incnmaster(1, wm),
+        .inc_master => incnmaster(if (int_arg != 0) int_arg else 1, wm),
         .dec_master => incnmaster(-1, wm),
         .toggle_floating => toggleFloating(wm),
         .toggle_fullscreen => toggleFullscreen(wm),
@@ -810,9 +810,9 @@ pub fn executeAction(action: config_mod.Action, int_arg: i32, str_arg: ?[]const 
             const tag_mask: u32 = @as(u32, 1) << @intCast(int_arg);
             core.view(tag_mask, wm);
         },
-        .view_next_tag => viewAdjacentTag(1, wm),
+        .view_next_tag => viewAdjacentTag(if (int_arg != 0) int_arg else 1, wm),
         .view_prev_tag => viewAdjacentTag(-1, wm),
-        .view_next_nonempty_tag => viewAdjacentNonemptyTag(1, wm),
+        .view_next_nonempty_tag => viewAdjacentNonemptyTag(if (int_arg != 0) int_arg else 1, wm),
         .view_prev_nonempty_tag => viewAdjacentNonemptyTag(-1, wm),
         .move_to_tag => {
             const tag_mask: u32 = @as(u32, 1) << @intCast(int_arg);
@@ -828,7 +828,7 @@ pub fn executeAction(action: config_mod.Action, int_arg: i32, str_arg: ?[]const 
         },
         .focus_monitor => focusmon(int_arg, wm),
         .send_to_monitor => sendmon(int_arg, wm),
-        .scroll_left => core.scrollLayout(-1, wm),
-        .scroll_right => core.scrollLayout(1, wm),
+        .scroll_left => core.scrollLayout(if (int_arg != 0) int_arg else -1, wm),
+        .scroll_right => core.scrollLayout(if (int_arg != 0) int_arg else 1, wm),
     }
 }


### PR DESCRIPTION
Fixed moving window and moving focus keybinds to actually work removing the hardcoded values from the moving functions and reimplementing them properly

Fixes #161 and #113