### PR TITLE
Disable window cycling in focusstack

### DIFF
--- a/src/wm/actions.zig
+++ b/src/wm/actions.zig
@@ -296,15 +296,6 @@ pub fn focusstack(direction: i32, wm: *WindowManager) void {
             }
             next_client = client.next;
         }
-        if (next_client == null) {
-            next_client = monitor.clients;
-            while (next_client) |client| {
-                if (client_mod.isVisible(client)) {
-                    break;
-                }
-                next_client = client.next;
-            }
-        }
     } else {
         var prev: ?*Client = null;
         var iter = monitor.clients;
@@ -316,15 +307,6 @@ pub fn focusstack(direction: i32, wm: *WindowManager) void {
                 prev = client;
             }
             iter = client.next;
-        }
-        if (prev == null) {
-            iter = current.next;
-            while (iter) |client| {
-                if (client_mod.isVisible(client)) {
-                    prev = client;
-                }
-                iter = client.next;
-            }
         }
         next_client = prev;
     }


### PR DESCRIPTION
Remove the wrap-around logic so that focusing past the last visible window does not jump to the first, and focusing before the first does not jump to the last. This makes the end of the client list act as a hard boundary.