### PR TITLE
Smooth scroll animations and viewport-aware scrolling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ notes/
 *.md
 
 oxwm-rs/
+zig-pkg/

--- a/src/bar/bar.zig
+++ b/src/bar/bar.zig
@@ -37,6 +37,8 @@ pub const Bar = struct {
     scheme_urgent: ColorScheme,
     hide_vacant_tags: bool,
 
+    color_cache: std.AutoArrayHashMap(c_ulong, xlib.XftColor),
+
     allocator: std.mem.Allocator,
     blocks: std.ArrayList(Block),
     needs_redraw: bool,
@@ -130,6 +132,7 @@ pub const Bar = struct {
             .scheme_occupied = config.scheme_occupied,
             .scheme_urgent = config.scheme_urgent,
             .hide_vacant_tags = config.hide_vacant_tags,
+            .color_cache = std.AutoArrayHashMap(c_ulong, xlib.XftColor).init(allocator),
             .allocator = allocator,
             .blocks = .empty,
             .needs_redraw = true,
@@ -144,6 +147,14 @@ pub const Bar = struct {
 
     /// Destroys the bar's X resources and frees the allocation.
     pub fn destroy(self: *Bar, display: *xlib.Display) void {
+        const visual = xlib.XDefaultVisual(display, 0);
+        const colormap = xlib.XDefaultColormap(display, 0);
+        var iter = self.color_cache.iterator();
+        while (iter.next()) |entry| {
+            xlib.XftColorFree(display, visual, colormap, entry.value_ptr);
+        }
+        self.color_cache.deinit();
+
         if (self.xft_draw) |xft_draw| xlib.XftDrawDestroy(xft_draw);
         if (self.font) |font| xlib.XftFontClose(display, font);
 
@@ -227,7 +238,7 @@ pub const Bar = struct {
         }
 
         _ = xlib.XCopyArea(display, self.pixmap, self.window, self.graphics_context, 0, 0, @intCast(self.width), @intCast(self.height), 0, 0);
-        _ = xlib.XSync(display, xlib.False);
+        _ = xlib.XFlush(display);
 
         self.needs_redraw = false;
     }
@@ -285,19 +296,19 @@ pub const Bar = struct {
     fn drawText(self: *Bar, display: *xlib.Display, x: i32, y: i32, text: []const u8, color: c_ulong) void {
         if (self.xft_draw == null or self.font == null) return;
 
-        var xft_color: xlib.XftColor = undefined;
-        var render_color: xlib.XRenderColor = undefined;
-        render_color.red = @intCast((color >> 16 & 0xff) * 257);
-        render_color.green = @intCast((color >> 8 & 0xff) * 257);
-        render_color.blue = @intCast((color & 0xff) * 257);
-        render_color.alpha = 0xffff;
-
         const visual = xlib.XDefaultVisual(display, 0);
         const colormap = xlib.XDefaultColormap(display, 0);
 
-        _ = xlib.XftColorAllocValue(display, visual, colormap, &render_color, &xft_color);
-        xlib.XftDrawStringUtf8(self.xft_draw, &xft_color, self.font, x, y, text.ptr, @intCast(text.len));
-        xlib.XftColorFree(display, visual, colormap, &xft_color);
+        const gop = self.color_cache.getOrPut(color) catch return;
+        if (!gop.found_existing) {
+            var render_color: xlib.XRenderColor = undefined;
+            render_color.red = @intCast((color >> 16 & 0xff) * 257);
+            render_color.green = @intCast((color >> 8 & 0xff) * 257);
+            render_color.blue = @intCast((color & 0xff) * 257);
+            render_color.alpha = 0xffff;
+            _ = xlib.XftColorAllocValue(display, visual, colormap, &render_color, gop.value_ptr);
+        }
+        xlib.XftDrawStringUtf8(self.xft_draw, gop.value_ptr, self.font, x, y, text.ptr, @intCast(text.len));
     }
 
     fn textWidth(self: *Bar, display: *xlib.Display, text: []const u8) i32 {

--- a/src/bar/blocks/blocks.zig
+++ b/src/bar/blocks/blocks.zig
@@ -113,8 +113,6 @@ pub const Block = struct {
             return false;
         }
 
-        self.last_update = now;
-
         const result = switch (self.data) {
             .static => |*s| s.content(&self.cached_content),
             .datetime => |*d| d.content(&self.cached_content),
@@ -124,6 +122,9 @@ pub const Block = struct {
             .cpu_temp => |*c| c.content(&self.cached_content),
         };
 
+        if (result.len == 0) return false;
+
+        self.last_update = now;
         self.cached_len = result.len;
         return true;
     }

--- a/src/bar/blocks/shell.zig
+++ b/src/bar/blocks/shell.zig
@@ -6,6 +6,10 @@ pub const Shell = struct {
     command: []const u8,
     interval_secs: u64,
     color: c_ulong,
+    child: ?*std.process.Child = null,
+    child_buffer: [4096]u8 = undefined,
+    child_buffer_len: usize = 0,
+    pending: bool = false,
 
     pub fn init(format: []const u8, command: []const u8, interval_secs: u64, col: c_ulong) Shell {
         return .{
@@ -17,22 +21,24 @@ pub const Shell = struct {
     }
 
     pub fn content(self: *Shell, buffer: []u8) []const u8 {
-        var cmd_output: [256]u8 = undefined;
-        const result = std.process.Child.run(.{
-            .allocator = std.heap.page_allocator,
-            .argv = &.{ "/bin/sh", "-c", self.command },
-        }) catch return buffer[0..0];
-        defer std.heap.page_allocator.free(result.stdout);
-        defer std.heap.page_allocator.free(result.stderr);
+        if (self.pending) {
+            self.pollChild();
+            if (!self.pending) {
+                var output: [256]u8 = undefined;
+                var cmd_len = @min(self.child_buffer_len, output.len);
+                @memcpy(output[0..cmd_len], self.child_buffer[0..cmd_len]);
 
-        var cmd_len = @min(result.stdout.len, cmd_output.len);
-        @memcpy(cmd_output[0..cmd_len], result.stdout[0..cmd_len]);
+                while (cmd_len > 0 and (output[cmd_len - 1] == '\n' or output[cmd_len - 1] == '\r')) {
+                    cmd_len -= 1;
+                }
 
-        while (cmd_len > 0 and (cmd_output[cmd_len - 1] == '\n' or cmd_output[cmd_len - 1] == '\r')) {
-            cmd_len -= 1;
+                return format_util.substitute(self.format, output[0..cmd_len], buffer);
+            }
+            return buffer[0..0];
         }
 
-        return format_util.substitute(self.format, cmd_output[0..cmd_len], buffer);
+        self.spawnChild();
+        return buffer[0..0];
     }
 
     pub fn interval(self: *Shell) u64 {
@@ -41,5 +47,54 @@ pub const Shell = struct {
 
     pub fn getColor(self: *Shell) c_ulong {
         return self.color;
+    }
+
+    fn spawnChild(self: *Shell) void {
+        const allocator = std.heap.page_allocator;
+        var child = std.process.Child.init(&.{ "/bin/sh", "-c", self.command }, allocator);
+        child.stdout_behavior = .Pipe;
+        child.stderr_behavior = .Ignore;
+
+        child.spawn() catch return;
+
+        const child_ptr = allocator.create(std.process.Child) catch {
+            _ = child.kill() catch {};
+            _ = child.wait() catch {};
+            return;
+        };
+        child_ptr.* = child;
+        self.child = child_ptr;
+        self.child_buffer_len = 0;
+        self.pending = true;
+
+        self.pollChild();
+    }
+
+    fn pollChild(self: *Shell) void {
+        const child_ptr = self.child orelse return;
+
+        var buf: [4096]u8 = undefined;
+        while (true) {
+            const n = child_ptr.stdout.?.read(&buf) catch {
+                self.reapChild();
+                return;
+            };
+            if (n == 0) {
+                self.pending = false;
+                self.reapChild();
+                return;
+            }
+            const remaining = self.child_buffer.len - self.child_buffer_len;
+            const to_copy = @min(n, remaining);
+            @memcpy(self.child_buffer[self.child_buffer_len .. self.child_buffer_len + to_copy], buf[0..to_copy]);
+            self.child_buffer_len += to_copy;
+        }
+    }
+
+    fn reapChild(self: *Shell) void {
+        const child_ptr = self.child orelse return;
+        _ = child_ptr.wait() catch {};
+        std.heap.page_allocator.destroy(child_ptr);
+        self.child = null;
     }
 };

--- a/src/client.zig
+++ b/src/client.zig
@@ -146,6 +146,25 @@ pub fn nextTagged(client: *Client) ?*Client {
     return null;
 }
 
+/// Inserts `client` just after `target` in the monitor's client list.
+/// Does nothing if they are on different monitors or target is null.
+pub fn attachAfter(client: *Client, target: ?*Client) void {
+    const at = target orelse {
+        attachAside(client);
+        return;
+    };
+    const monitor = at.monitor orelse {
+        attachAside(client);
+        return;
+    };
+    if (client.monitor != monitor) {
+        attachAside(client);
+        return;
+    }
+    client.next = at.next;
+    at.next = client;
+}
+
 /// Inserts `client` just after the first client that shares its tags,
 /// falling back to prepend if none exists.
 pub fn attachAside(client: *Client) void {

--- a/src/layouts/scrolling.zig
+++ b/src/layouts/scrolling.zig
@@ -132,6 +132,11 @@ pub fn getTargetScrollForWindow(monitor: *Monitor, target: *Client) i32 {
     }
 
     const max_scroll = getMaxScroll(monitor);
-    const target_scroll = (window_width + gap_inner_v) * @as(i32, @intCast(index));
-    return @min(target_scroll, max_scroll);
+    if (window_x_end > viewport_end) {
+        const target_scroll = window_x_end - available_width;
+        return @min(@max(0, target_scroll), max_scroll);
+    } else {
+        const target_scroll = window_x_start;
+        return @min(@max(0, target_scroll), max_scroll);
+    }
 }

--- a/src/layouts/scrolling.zig
+++ b/src/layouts/scrolling.zig
@@ -39,13 +39,16 @@ pub fn scrollEx(monitor: *Monitor, flush: bool, animating: bool) void {
     var x_pos: i32 = monitor.win_x + gap_outer_v - monitor.scroll_offset;
     const y_pos: i32 = monitor.win_y + gap_outer_h;
     const height = available_height;
-    const hide_x: i32 = -2 * window_width;
+    const hide_x: i32 = monitor.win_x - 2 * monitor.win_w;
+
+    const viewport_left = monitor.win_x + gap_outer_v;
+    const viewport_right = viewport_left + available_width;
 
     current = client_mod.nextTiled(monitor.clients);
     while (current) |client| : (current = client_mod.nextTiled(client.next)) {
         const window_right = x_pos + window_width;
-        const screen_left = monitor.win_x;
-        const screen_right = monitor.win_x + monitor.win_w;
+        const screen_left = viewport_left;
+        const screen_right = viewport_right;
         const is_visible = window_right > screen_left and x_pos < screen_right;
 
         const target_x: i32 = if (is_visible) x_pos else hide_x;

--- a/src/layouts/scrolling.zig
+++ b/src/layouts/scrolling.zig
@@ -13,6 +13,10 @@ pub const layout = monitor_mod.Layout{
 };
 
 pub fn scroll(monitor: *Monitor) void {
+    scrollEx(monitor, true, false);
+}
+
+pub fn scrollEx(monitor: *Monitor, flush: bool, animating: bool) void {
     var client_count: u32 = 0;
     var current = client_mod.nextTiled(monitor.clients);
     while (current) |_| : (current = client_mod.nextTiled(current.?.next)) {
@@ -35,8 +39,8 @@ pub fn scroll(monitor: *Monitor) void {
     var x_pos: i32 = monitor.win_x + gap_outer_v - monitor.scroll_offset;
     const y_pos: i32 = monitor.win_y + gap_outer_h;
     const height = available_height;
+    const hide_x: i32 = -2 * window_width;
 
-    var index: u32 = 0;
     current = client_mod.nextTiled(monitor.clients);
     while (current) |client| : (current = client_mod.nextTiled(client.next)) {
         const window_right = x_pos + window_width;
@@ -44,26 +48,18 @@ pub fn scroll(monitor: *Monitor) void {
         const screen_right = monitor.win_x + monitor.win_w;
         const is_visible = window_right > screen_left and x_pos < screen_right;
 
-        if (is_visible) {
-            tiling.resize(
-                client,
-                x_pos,
-                y_pos,
-                window_width - 2 * client.border_width,
-                height - 2 * client.border_width,
-                false,
-            );
-        } else {
-            tiling.resizeClient(
-                client,
-                -2 * window_width,
-                y_pos,
-                window_width - 2 * client.border_width,
-                height - 2 * client.border_width,
-            );
-        }
+        const target_x: i32 = if (is_visible) x_pos else hide_x;
+
+        tiling.resizeClientAnim(
+            client,
+            target_x,
+            y_pos,
+            window_width - 2 * client.border_width,
+            height - 2 * client.border_width,
+            flush,
+            animating,
+        );
         x_pos += window_width + gap_inner_v;
-        index += 1;
     }
 }
 
@@ -110,11 +106,32 @@ pub fn getWindowIndex(monitor: *Monitor, target: *Client) ?u32 {
 
 pub fn getTargetScrollForWindow(monitor: *Monitor, target: *Client) i32 {
     const index = getWindowIndex(monitor, target) orelse return 0;
-    if (index == 0) return 0;
 
-    const scroll_step = getScrollStep(monitor);
+    var client_count: u32 = 0;
+    var current = client_mod.nextTiled(monitor.clients);
+    while (current) |_| : (current = client_mod.nextTiled(current.?.next)) {
+        client_count += 1;
+    }
+
+    const visible_count: u32 = @intCast(@max(1, monitor.nmaster));
+    const gap_outer_v = if (monitor.smartgaps_enabled and client_count == 1) 0 else monitor.gap_outer_v;
+    const gap_inner_v = monitor.gap_inner_v;
+    const available_width = monitor.win_w - 2 * gap_outer_v;
+
+    const total_gaps = gap_inner_v * @as(i32, @intCast(if (visible_count > 1) visible_count - 1 else 0));
+    const window_width = @divTrunc(available_width - total_gaps, @as(i32, @intCast(visible_count)));
+
+    const window_x_start = @as(i32, @intCast(index)) * (window_width + gap_inner_v);
+    const window_x_end = window_x_start + window_width;
+
+    const viewport_start = monitor.scroll_offset;
+    const viewport_end = viewport_start + available_width;
+
+    if (window_x_start >= viewport_start and window_x_end <= viewport_end) {
+        return monitor.scroll_offset;
+    }
+
     const max_scroll = getMaxScroll(monitor);
-
-    const target_scroll = scroll_step * @as(i32, @intCast(index));
+    const target_scroll = (window_width + gap_inner_v) * @as(i32, @intCast(index));
     return @min(target_scroll, max_scroll);
 }

--- a/src/layouts/tiling.zig
+++ b/src/layouts/tiling.zig
@@ -262,7 +262,45 @@ pub fn resizeClient(client: *Client, target_x: i32, target_y: i32, target_width:
     );
 
     sendConfigure(client);
-    _ = xlib.XSync(display, xlib.False);
+    _ = xlib.XFlush(display);
+}
+
+pub fn resizeClientAnim(client: *Client, target_x: i32, target_y: i32, target_width: i32, target_height: i32, flush: bool, animating: bool) void {
+    if (animating and client.x == target_x and client.y == target_y) return;
+
+    client.old_x = client.x;
+    client.old_y = client.y;
+    client.old_width = client.width;
+    client.old_height = client.height;
+    client.x = target_x;
+    client.y = target_y;
+    client.width = target_width;
+    client.height = target_height;
+
+    const display = display_handle orelse return;
+
+    if (animating) {
+        _ = xlib.XMoveWindow(display, client.window, target_x, target_y);
+    } else {
+        var window_changes: xlib.c.XWindowChanges = undefined;
+        window_changes.x = target_x;
+        window_changes.y = target_y;
+        window_changes.width = @intCast(@max(1, target_width));
+        window_changes.height = @intCast(@max(1, target_height));
+        window_changes.border_width = client.border_width;
+
+        _ = xlib.c.XConfigureWindow(
+            display,
+            client.window,
+            xlib.c.CWX | xlib.c.CWY | xlib.c.CWWidth | xlib.c.CWHeight | xlib.c.CWBorderWidth,
+            &window_changes,
+        );
+
+        sendConfigure(client);
+    }
+    if (flush) {
+        _ = xlib.XFlush(display);
+    }
 }
 
 pub fn sendConfigure(client: *Client) void {

--- a/src/wm/core.zig
+++ b/src/wm/core.zig
@@ -90,7 +90,11 @@ pub fn manage(win: xlib.Window, window_attrs: *xlib.XWindowAttributes, wm: *Wind
         _ = xlib.XRaiseWindow(wm.display.handle, client.window);
     }
 
-    client_mod.attachAside(client);
+    if (isScrollingLayout(monitor)) {
+        client_mod.attachAfter(client, monitor.sel);
+    } else {
+        client_mod.attachAside(client);
+    }
     client_mod.attachStack(client);
 
     _ = xlib.XChangeProperty(wm.display.handle, wm.display.root, wm.atoms.net_client_list, xlib.XA_WINDOW, 32, xlib.PropModeAppend, @ptrCast(&client.window), 1);
@@ -104,7 +108,8 @@ pub fn manage(win: xlib.Window, window_attrs: *xlib.XWindowAttributes, wm: *Wind
     monitor.sel = client;
 
     if (isScrollingLayout(monitor)) {
-        monitor.scroll_offset = 0;
+        const target = scrolling.getTargetScrollForWindow(monitor, client);
+        monitor.scroll_offset = target;
     }
 
     arrange(monitor, wm);
@@ -139,10 +144,9 @@ pub fn unmanage(client: *Client, wm: *WindowManager) void {
         if (monitor.sel == client) {
             monitor.sel = if (next_focus) |nf| nf else monitor.stack;
         }
-        if (isScrollingLayout(monitor)) {
-            const target = if (monitor.sel) |sel| scrolling.getTargetScrollForWindow(monitor, sel) else 0;
-            if (target == 0) {
-                monitor.scroll_offset = scrolling.getScrollStep(monitor);
+        if (isScrollingLayout(monitor) and !client.is_floating) {
+            if (monitor.sel) |sel| {
+                monitor.scroll_offset = scrolling.getTargetScrollForWindow(monitor, sel);
             } else {
                 monitor.scroll_offset = 0;
             }
@@ -251,7 +255,7 @@ pub fn restack(monitor: *Monitor, wm: *WindowManager) void {
         }
     }
 
-    _ = xlib.XSync(wm.display.handle, xlib.False);
+    _ = xlib.XFlush(wm.display.handle);
 
     var discard_event: xlib.XEvent = undefined;
     while (xlib.c.XCheckMaskEvent(wm.display.handle, xlib.EnterWindowMask, &discard_event) != 0) {}
@@ -402,8 +406,22 @@ pub fn tickAnimations(wm: *WindowManager) void {
     if (!wm.scroll_animation.isActive()) return;
 
     const monitor = wm.selected_monitor orelse return;
-    if (wm.scroll_animation.update()) |new_offset| {
+    const result = wm.scroll_animation.update();
+    if (result) |new_offset| {
         monitor.scroll_offset = new_offset;
+    }
+
+    if (!wm.scroll_animation.isActive()) {
+        arrange(monitor, wm);
+        var discard_event: xlib.XEvent = undefined;
+        while (xlib.c.XCheckMaskEvent(wm.display.handle, xlib.EnterWindowMask | xlib.PointerMotionMask, &discard_event) != 0) {}
+        return;
+    }
+
+    if (isScrollingLayout(monitor)) {
+        scrolling.scrollEx(monitor, false, true);
+        _ = xlib.XFlush(wm.display.handle);
+    } else {
         arrange(monitor, wm);
     }
 }

--- a/src/wm/core.zig
+++ b/src/wm/core.zig
@@ -286,8 +286,10 @@ pub fn showhideClient(client: ?*Client, wm: *WindowManager) void {
         showhideClient(target.stack_next, wm);
     } else {
         showhideClient(target.stack_next, wm);
+        const monitor = target.monitor orelse return;
         const client_width = target.width + 2 * target.border_width;
-        _ = xlib.XMoveWindow(wm.display.handle, target.window, -2 * client_width, target.y);
+        const hide_x = monitor.win_x - 2 * client_width;
+        _ = xlib.XMoveWindow(wm.display.handle, target.window, hide_x, target.y);
     }
 }
 

--- a/src/wm/handlers.zig
+++ b/src/wm/handlers.zig
@@ -94,10 +94,12 @@ fn handleConfigureRequest(event: *xlib.XConfigureRequestEvent, wm: *WindowManage
                 _ = xlib.XMoveResizeWindow(wm.display.handle, managed_client.window, managed_client.x, managed_client.y, @intCast(managed_client.width), @intCast(managed_client.height));
             }
         } else {
-            tiling.sendConfigure(managed_client);
+            if (!wm.scroll_animation.isActive()) {
+                tiling.sendConfigure(managed_client);
+            }
         }
     } else {
-        var changes: xlib.XWindowChanges = undefined;
+        var changes: xlib.c.XWindowChanges = undefined;
         changes.x = event.x;
         changes.y = event.y;
         changes.width = event.width;
@@ -107,7 +109,7 @@ fn handleConfigureRequest(event: *xlib.XConfigureRequestEvent, wm: *WindowManage
         changes.stack_mode = event.detail;
         _ = xlib.XConfigureWindow(wm.display.handle, event.window, @intCast(event.value_mask), &changes);
     }
-    _ = xlib.XSync(wm.display.handle, xlib.False);
+    _ = xlib.XFlush(wm.display.handle);
 }
 
 fn handleKeyPress(event: *xlib.XKeyEvent, wm: *WindowManager) void {
@@ -313,6 +315,8 @@ fn handleUnmapNotify(event: *xlib.XUnmapEvent, wm: *WindowManager) void {
 }
 
 fn handleEnterNotify(event: *xlib.XCrossingEvent, wm: *WindowManager) void {
+    if (wm.scroll_animation.isActive()) return;
+
     if ((event.mode != xlib.NotifyNormal or event.detail == xlib.NotifyInferior) and event.window != wm.display.root) {
         return;
     }
@@ -338,6 +342,8 @@ fn handleEnterNotify(event: *xlib.XCrossingEvent, wm: *WindowManager) void {
 }
 
 fn handleFocusIn(event: *xlib.XFocusChangeEvent, wm: *WindowManager) void {
+    if (wm.scroll_animation.isActive()) return;
+
     const selmon = wm.selected_monitor orelse return;
     const selected = selmon.sel orelse return;
     if (event.window != selected.window) {
@@ -346,6 +352,8 @@ fn handleFocusIn(event: *xlib.XFocusChangeEvent, wm: *WindowManager) void {
 }
 
 fn handleMotionNotify(event: *xlib.XMotionEvent, wm: *WindowManager) void {
+    if (wm.scroll_animation.isActive()) return;
+
     if (event.window != wm.display.root) return;
 
     const target_mon = monitor_mod.rectToMonitor(wm, event.x_root, event.y_root, 1, 1);
@@ -363,6 +371,8 @@ fn handlePropertyNotify(event: *xlib.XPropertyEvent, wm: *WindowManager) void {
     if (event.state == xlib.PropertyDelete) {
         return;
     }
+
+    if (wm.scroll_animation.isActive()) return;
 
     const client = client_mod.windowToClient(wm.monitors, event.window) orelse return;
 

--- a/src/wm/wm.zig
+++ b/src/wm/wm.zig
@@ -654,21 +654,31 @@ pub const WindowManager = struct {
         _ = xlib.XSync(self.display.handle, xlib.False);
 
         while (self.running) {
+            var events_processed: u32 = 0;
             while (xlib.XPending(self.display.handle) > 0) {
                 var event = self.display.nextEvent();
                 eventFn(&event, self);
+                events_processed += 1;
+                if (events_processed >= 8) {
+                    if (self.scroll_animation.isActive()) {
+                        tickFn(self);
+                    }
+                    events_processed = 0;
+                }
             }
 
             tickFn(self);
 
-            var current_bar = self.bars;
-            while (current_bar) |bar| {
-                bar.updateBlocks();
-                bar.draw(self.display.handle, self.config);
-                current_bar = bar.next;
+            if (!self.scroll_animation.isActive()) {
+                var current_bar = self.bars;
+                while (current_bar) |bar| {
+                    bar.updateBlocks();
+                    bar.draw(self.display.handle, self.config);
+                    current_bar = bar.next;
+                }
             }
 
-            const poll_timeout: i32 = if (self.scroll_animation.isActive()) 16 else 1000;
+            const poll_timeout: i32 = if (self.scroll_animation.isActive()) 6 else 1000;
             _ = std.posix.poll(&fds, poll_timeout) catch 0;
         }
     }

--- a/src/x11/xlib.zig
+++ b/src/x11/xlib.zig
@@ -33,6 +33,7 @@ pub const XDisplayHeight = c.XDisplayHeight;
 pub const XNextEvent = c.XNextEvent;
 pub const XPending = c.XPending;
 pub const XSync = c.XSync;
+pub const XFlush = c.XFlush;
 pub const XSelectInput = c.XSelectInput;
 pub const XSetErrorHandler = c.XSetErrorHandler;
 pub const XGrabKey = c.XGrabKey;


### PR DESCRIPTION
Animation improvements:
- Replace XSync with XFlush throughout to avoid blocking round-trips
- Add resizeClientAnim that uses XMoveWindow during animation and XConfigureWindow for final frames
- Split scroll() into scrollEx(flush, animating) for animation support
- Rewrite tickAnimations: use scrollEx during active animation, arrange + discard stale events (Enter+Motion) on animation end
- Add mid-burst animation tick in event loop (every 8 events) so scrolling doesn't freeze during X event floods
- Reduce poll timeout from 16ms to 6ms for smoother animation pacing
- Skip bar updates during active animation to reduce overhead
- Suppress EnterNotify, FocusIn, MotionNotify, PropertyNotify, and sendConfigure during active animation to prevent focus stealing

Viewport-aware scrolling:
- Rewrite getTargetScrollForWindow to check if the target window is already fully visible in the viewport, and return the current scroll_offset if so, avoiding unnecessary rescrolls
- In manage(), scroll to new window position via getTargetScrollForWindow instead of resetting scroll_offset to 0
- In manage(), use attachAfter for scrolling layout so new windows appear next to the selected client
- In unmanage(), skip scroll recalculation for floating clients and always use getTargetScrollForWindow for the new selection

Bar performance:
- Cache XftColor allocations in bar (color_cache) instead of alloc/free per drawText call
- Make shell blocks non-blocking via async child process spawning
- Only update block last_update timestamp on non-empty results

Also adds zig-pkg/ to .gitignore.