### PR TITLE
fix: pass int_arg to focusstack/movestack dispatch

### DIFF
--- a/src/config/lua.zig
+++ b/src/config/lua.zig
@@ -590,14 +590,18 @@ fn luaClientToggleFloating(state: ?*c.lua_State) callconv(.c) c_int {
 
 fn luaClientFocusStack(state: ?*c.lua_State) callconv(.c) c_int {
     const s = state orelse return 0;
-    const dir: i32 = @intCast(c.lua_tointegerx(s, 1, null));
+    var isnum: c_int = 0;
+    const raw = c.lua_tointegerx(s, 1, &isnum);
+    const dir: i32 = if (isnum != 0) @intCast(raw) else 1;
     createActionTableWithInt(s, "FocusStack", dir);
     return 1;
 }
 
 fn luaClientMoveStack(state: ?*c.lua_State) callconv(.c) c_int {
     const s = state orelse return 0;
-    const dir: i32 = @intCast(c.lua_tointegerx(s, 1, null));
+    var isnum: c_int = 0;
+    const raw = c.lua_tointegerx(s, 1, &isnum);
+    const dir: i32 = if (isnum != 0) @intCast(raw) else 1;
     createActionTableWithInt(s, "MoveStack", dir);
     return 1;
 }

--- a/src/wm/actions.zig
+++ b/src/wm/actions.zig
@@ -69,6 +69,7 @@ pub fn spawnTerminal(wm: *WindowManager) void {
 }
 
 pub fn movestack(direction: i32, wm: *WindowManager) void {
+    if (direction == 0) return;
     const monitor = wm.selected_monitor orelse return;
     const current = monitor.sel orelse return;
 
@@ -289,6 +290,7 @@ pub fn tagClient(tag_mask: u32, wm: *WindowManager) void {
 }
 
 pub fn focusstack(direction: i32, wm: *WindowManager) void {
+    if (direction == 0) return;
     const monitor = wm.selected_monitor orelse return;
     const current = monitor.sel orelse return;
 

--- a/src/wm/actions.zig
+++ b/src/wm/actions.zig
@@ -797,9 +797,9 @@ pub fn executeAction(action: config_mod.Action, int_arg: i32, str_arg: ?[]const 
                 }
             }
         },
-        .focus_next => focusstack(1, wm),
+        .focus_next => focusstack(int_arg, wm),
         .focus_prev => focusstack(-1, wm),
-        .move_next => movestack(1, wm),
+        .move_next => movestack(int_arg, wm),
         .move_prev => movestack(-1, wm),
         .resize_master => setmfact(@as(f32, @floatFromInt(int_arg)) / 1000.0, wm),
         .inc_master => incnmaster(1, wm),


### PR DESCRIPTION
The .focus_next and .move_next dispatch arms hardcoded direction to 1, ignoring the int_arg passed from Lua via createActionTableWithInt. This caused oxwm.client.focus_stack(-1) and oxwm.client.move_stack(-1) to behave identically to their +1 counterparts; the .focus_prev and .move_prev variants were unreachable from the Lua side because parseAction maps both "FocusStack" and "MoveStack" only to the _next variants.

Pass int_arg through so direction works as documented.