### PR TITLE
Feat/per button block clicks

### DIFF
--- a/src/bar/bar.zig
+++ b/src/bar/bar.zig
@@ -258,12 +258,20 @@ pub const Bar = struct {
         return null;
     }
 
-    /// Returns the click action of the block the user clicked on, or null.
-    pub fn handleBlockClick(self: *Bar, click_x: i32) ?config_mod.ClickAction {
+    /// Returns the action bound to the given button on the block at click_x,
+    /// or null if no block is hit or no action is bound for that button.
+    /// Button numbers follow X11 convention: 1 = left, 2 = middle, 3 = right,
+    /// 4 = scroll up, 5 = scroll down.
+    pub fn handleBlockButton(self: *Bar, click_x: i32, button: u32) ?config_mod.ClickAction {
         for (self.blocks.items) |*block| {
-            if (block.click != null and click_x >= block.x_start and click_x < block.x_end) {
-                return block.click;
-            }
+            if (click_x < block.x_start or click_x >= block.x_end) continue;
+            return switch (button) {
+                1 => block.left_click orelse block.click,
+                3 => block.right_click,
+                4 => block.scroll_up,
+                5 => block.scroll_down,
+                else => null,
+            };
         }
         return null;
     }

--- a/src/bar/bar.zig
+++ b/src/bar/bar.zig
@@ -265,13 +265,20 @@ pub const Bar = struct {
     pub fn handleBlockButton(self: *Bar, click_x: i32, button: u32) ?config_mod.ClickAction {
         for (self.blocks.items) |*block| {
             if (click_x < block.x_start or click_x >= block.x_end) continue;
-            return switch (button) {
+            const action = switch (button) {
                 1 => block.left_click orelse block.click,
                 3 => block.right_click,
                 4 => block.scroll_up,
                 5 => block.scroll_down,
                 else => null,
             };
+            if (action != null) {
+                // The action likely changed the state this block displays
+                // (e.g. volume scroll). Force re-poll on the next update tick
+                // instead of waiting out the block's interval.
+                block.last_update = 0;
+            }
+            return action;
         }
         return null;
     }

--- a/src/bar/blocks/blocks.zig
+++ b/src/bar/blocks/blocks.zig
@@ -15,6 +15,10 @@ pub const Block = struct {
     cached_len: usize,
     underline: bool,
     click: ?config_mod.ClickAction = null,
+    left_click: ?config_mod.ClickAction = null,
+    right_click: ?config_mod.ClickAction = null,
+    scroll_up: ?config_mod.ClickAction = null,
+    scroll_down: ?config_mod.ClickAction = null,
     x_start: i32 = 0,
     x_end: i32 = 0,
 

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -165,6 +165,10 @@ pub const Block = struct {
     battery_name: ?[]const u8 = null,
     thermal_zone: ?[]const u8 = null,
     click: ?ClickAction = null,
+    left_click: ?ClickAction = null,
+    right_click: ?ClickAction = null,
+    scroll_up: ?ClickAction = null,
+    scroll_down: ?ClickAction = null,
 };
 
 pub const ColorScheme = struct {

--- a/src/config/lua.zig
+++ b/src/config/lua.zig
@@ -833,6 +833,22 @@ fn parseBlockConfig(state: *c.lua_State, idx: c_int) ?Block {
     const click = parseClickAction(state, -1);
     c.lua_settop(state, -2);
 
+    _ = c.lua_getfield(state, idx, "left_click");
+    const left_click = parseClickAction(state, -1);
+    c.lua_settop(state, -2);
+
+    _ = c.lua_getfield(state, idx, "right_click");
+    const right_click = parseClickAction(state, -1);
+    c.lua_settop(state, -2);
+
+    _ = c.lua_getfield(state, idx, "scroll_up");
+    const scroll_up = parseClickAction(state, -1);
+    c.lua_settop(state, -2);
+
+    _ = c.lua_getfield(state, idx, "scroll_down");
+    const scroll_down = parseClickAction(state, -1);
+    c.lua_settop(state, -2);
+
     var block = Block{
         .block_type = .static,
         .format = format,
@@ -840,6 +856,10 @@ fn parseBlockConfig(state: *c.lua_State, idx: c_int) ?Block {
         .color = color,
         .underline = underline,
         .click = click,
+        .left_click = left_click,
+        .right_click = right_click,
+        .scroll_up = scroll_up,
+        .scroll_down = scroll_down,
     };
 
     if (std.mem.eql(u8, block_type_str, "Ram")) {
@@ -960,7 +980,7 @@ fn luaBarBlockStatic(state: ?*c.lua_State) callconv(.c) c_int {
 fn luaBarBlockBattery(state: ?*c.lua_State) callconv(.c) c_int {
     const s = state orelse return 0;
 
-    c.lua_createtable(s, 0, 7);
+    c.lua_createtable(s, 0, 11);
 
     _ = c.lua_pushstring(s, "Battery");
     c.lua_setfield(s, -2, "__block_type");
@@ -980,6 +1000,18 @@ fn luaBarBlockBattery(state: ?*c.lua_State) callconv(.c) c_int {
     _ = c.lua_getfield(s, 1, "click");
     c.lua_setfield(s, -2, "click");
 
+    _ = c.lua_getfield(s, 1, "left_click");
+    c.lua_setfield(s, -2, "left_click");
+
+    _ = c.lua_getfield(s, 1, "right_click");
+    c.lua_setfield(s, -2, "right_click");
+
+    _ = c.lua_getfield(s, 1, "scroll_up");
+    c.lua_setfield(s, -2, "scroll_up");
+
+    _ = c.lua_getfield(s, 1, "scroll_down");
+    c.lua_setfield(s, -2, "scroll_down");
+
     c.lua_createtable(s, 0, 4);
     _ = c.lua_getfield(s, 1, "charging");
     c.lua_setfield(s, -2, "charging");
@@ -995,7 +1027,7 @@ fn luaBarBlockBattery(state: ?*c.lua_State) callconv(.c) c_int {
 }
 
 fn createBlockTable(state: *c.lua_State, block_type: [*:0]const u8, arg: ?[]const u8) void {
-    c.lua_createtable(state, 0, 7);
+    c.lua_createtable(state, 0, 11);
 
     _ = c.lua_pushstring(state, block_type);
     c.lua_setfield(state, -2, "__block_type");
@@ -1014,6 +1046,18 @@ fn createBlockTable(state: *c.lua_State, block_type: [*:0]const u8, arg: ?[]cons
 
     _ = c.lua_getfield(state, 1, "click");
     c.lua_setfield(state, -2, "click");
+
+    _ = c.lua_getfield(state, 1, "left_click");
+    c.lua_setfield(state, -2, "left_click");
+
+    _ = c.lua_getfield(state, 1, "right_click");
+    c.lua_setfield(state, -2, "right_click");
+
+    _ = c.lua_getfield(state, 1, "scroll_up");
+    c.lua_setfield(state, -2, "scroll_up");
+
+    _ = c.lua_getfield(state, 1, "scroll_down");
+    c.lua_setfield(state, -2, "scroll_down");
 
     if (arg) |a| {
         var buf: [256]u8 = undefined;

--- a/src/wm/handlers.zig
+++ b/src/wm/handlers.zig
@@ -232,7 +232,7 @@ fn handleButtonPress(event: *xlib.XButtonEvent, wm: *WindowManager) void {
         if (clicked_tag) |tag_index| {
             const tag_mask: u32 = @as(u32, 1) << @intCast(tag_index);
             core.view(tag_mask, wm);
-        } else if (bar.handleBlockClick(event.x)) |click_action| {
+        } else if (bar.handleBlockButton(event.x, event.button)) |click_action| {
             wm.next_spawn_floating = click_action.floating;
             wm.next_spawn_bypass_rules = click_action.bypass_rules;
             actions.spawnCommand(wm, click_action.command);

--- a/src/wm/handlers.zig
+++ b/src/wm/handlers.zig
@@ -236,6 +236,9 @@ fn handleButtonPress(event: *xlib.XButtonEvent, wm: *WindowManager) void {
             wm.next_spawn_floating = click_action.floating;
             wm.next_spawn_bypass_rules = click_action.bypass_rules;
             actions.spawnCommand(wm, click_action.command);
+            // Re-poll blocks now so e.g. volume scroll reflects immediately.
+            // handleBlockButton already reset the matched block's last_update.
+            bar.updateBlocks();
         }
         return;
     }

--- a/src/wm/wm.zig
+++ b/src/wm/wm.zig
@@ -747,5 +747,9 @@ pub fn configBlockToBarBlock(cfg: config_mod.Block) blocks_mod.Block {
         ),
     };
     block.click = cfg.click;
+    block.left_click = cfg.left_click;
+    block.right_click = cfg.right_click;
+    block.scroll_up = cfg.scroll_up;
+    block.scroll_down = cfg.scroll_down;
     return block;
 }


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                    
  Today every mouse event on a bar block fires the single `click` action regardless of which button pressed it (`handleButtonPress` ignores `event.button`). This PR adds four optional `ClickAction` fields per block — `left_click`, `right_click`, `scroll_up`, `scroll_down` and dispatches by X11 button number.                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                    
  | Button | Field |                                                                                                                                                                                                                                                                
  |---|---|                                                                                                                                                                                                                                                                         
  | 1 (left) | `left_click` (falls back to legacy `click` if unset) |
  | 3 (right) | `right_click` |
  | 4 (scroll up) | `scroll_up` |                                                                                                                                                                                                                                                   
  | 5 (scroll down) | `scroll_down` |
                                                                                                                                                                                                                                                                                    
  ## Backwards compatibility                 

  Existing configs that only set `click =` keep working unchanged. The legacy field is treated as a `left_click` alias when no per-button field is set. No removed APIs.                                                                                                            
   
  ## Refresh-on-click                                                                                                                                                                                                                                                               
                                             
  The second commit makes the affected block re-poll immediately after a click action runs. Without it, scroll-to-adjust feels sluggish: e.g. with `interval=2`, the displayed value lags 0–2s behind the click. Implementation: `handleBlockButton` resets `block.last_update = 0` 
  when an action matches, and `handleButtonPress` calls `bar.updateBlocks()` right after `spawnCommand`. The spawned action is async (fork+exec), but external commands are fast enough that the immediate re-poll observes the new value in practice.
                                                                                                                                                                                                                                                                                    
  ## Files touched                           

  - `src/config/config.zig` — 4 new optional `ClickAction` fields on `Block`                                                                                                                                                                                                        
  - `src/bar/blocks/blocks.zig` — same 4 fields on the runtime `Block` struct
  - `src/config/lua.zig` — forward fields through `createBlockTable` and `luaBarBlockBattery`; parse them in `parseBlockConfig`                                                                                                                                                     
  - `src/bar/bar.zig` — replace `handleBlockClick` with `handleBlockButton(x, button)`; reset `last_update` on match                                                                                                                                                                
  - `src/wm/wm.zig` — copy fields in `configBlockToBarBlock`                                                                                                                                                                                                                        
  - `src/wm/handlers.zig` — pass `event.button` to dispatcher; call `updateBlocks()` after spawn                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                    
  ## Example                                 
                                                                                                                                                                                                                                                                                    
  ```lua                                     
  oxwm.bar.block.shell({
      format = "{}",                                                                                                                                                                                                                                                                
      command = "echo hi",
      scroll_up    = "...",                                                                                                                                                                                                                                                         
      scroll_down  = "...",                  
      right_click  = "...",
      left_click   = "...",
  })