### PR TITLE
feat: native volume block

### DIFF
--- a/src/bar/blocks/blocks.zig
+++ b/src/bar/blocks/blocks.zig
@@ -7,6 +7,7 @@ pub const Ram = @import("ram.zig").Ram;
 pub const Shell = @import("shell.zig").Shell;
 pub const Battery = @import("battery.zig").Battery;
 pub const CpuTemp = @import("cpu_temp.zig").CpuTemp;
+pub const Volume = @import("volume.zig").Volume;
 
 pub const Block = struct {
     data: Data,
@@ -25,6 +26,7 @@ pub const Block = struct {
         shell: Shell,
         battery: Battery,
         cpu_temp: CpuTemp,
+        volume: Volume,
     };
 
     pub fn initStatic(text: []const u8, col: c_ulong, ul: bool) Block {
@@ -104,6 +106,23 @@ pub const Block = struct {
         };
     }
 
+    pub fn initVolume(
+        format: []const u8,
+        format_muted: []const u8,
+        sink: []const u8,
+        interval_secs: u64,
+        col: c_ulong,
+        ul: bool,
+    ) Block {
+        return .{
+            .data = .{ .volume = Volume.init(format, format_muted, sink, interval_secs, col) },
+            .last_update = 0,
+            .cached_content = undefined,
+            .cached_len = 0,
+            .underline = ul,
+        };
+    }
+
     pub fn update(self: *Block) bool {
         const interval_secs = self.interval();
         if (interval_secs == 0) return false;
@@ -122,6 +141,7 @@ pub const Block = struct {
             .shell => |*s| s.content(&self.cached_content),
             .battery => |*b| b.content(&self.cached_content),
             .cpu_temp => |*c| c.content(&self.cached_content),
+            .volume => |*v| v.content(&self.cached_content),
         };
 
         self.cached_len = result.len;
@@ -136,6 +156,7 @@ pub const Block = struct {
             .shell => |*s| s.interval(),
             .battery => |*b| b.interval(),
             .cpu_temp => |*c| c.interval(),
+            .volume => |*v| v.interval(),
         };
     }
 
@@ -147,6 +168,7 @@ pub const Block = struct {
             .shell => |s| s.color,
             .battery => |b| b.color,
             .cpu_temp => |c| c.color,
+            .volume => |v| v.color,
         };
     }
 

--- a/src/bar/blocks/volume.zig
+++ b/src/bar/blocks/volume.zig
@@ -1,0 +1,77 @@
+const std = @import("std");
+const format_util = @import("format.zig");
+
+pub const Volume = struct {
+    format: []const u8,
+    format_muted: []const u8,
+    sink: []const u8,
+    interval_secs: u64,
+    color: c_ulong,
+
+    pub fn init(
+        format: []const u8,
+        format_muted: []const u8,
+        sink: []const u8,
+        interval_secs: u64,
+        color: c_ulong,
+    ) Volume {
+        return .{
+            .format = format,
+            .format_muted = format_muted,
+            .sink = if (sink.len > 0) sink else "@DEFAULT_SINK@",
+            .interval_secs = interval_secs,
+            .color = color,
+        };
+    }
+
+    pub fn content(self: *Volume, buffer: []u8) []const u8 {
+        if (self.isMuted()) {
+            return format_util.substitute(self.format_muted, "", buffer);
+        }
+        const percent = self.readVolume() orelse return buffer[0..0];
+        var pct_buf: [8]u8 = undefined;
+        const pct_str = std.fmt.bufPrint(&pct_buf, "{d}", .{percent}) catch return buffer[0..0];
+        return format_util.substitute(self.format, pct_str, buffer);
+    }
+
+    fn isMuted(self: *Volume) bool {
+        const result = std.process.Child.run(.{
+            .allocator = std.heap.page_allocator,
+            .argv = &.{ "pactl", "get-sink-mute", self.sink },
+        }) catch return false;
+        defer std.heap.page_allocator.free(result.stdout);
+        defer std.heap.page_allocator.free(result.stderr);
+        // Output: "Mute: yes" or "Mute: no"
+        return std.mem.indexOf(u8, result.stdout, "yes") != null;
+    }
+
+    fn readVolume(self: *Volume) ?u32 {
+        const result = std.process.Child.run(.{
+            .allocator = std.heap.page_allocator,
+            .argv = &.{ "pactl", "get-sink-volume", self.sink },
+        }) catch return null;
+        defer std.heap.page_allocator.free(result.stdout);
+        defer std.heap.page_allocator.free(result.stderr);
+        // Output (one line): "Volume: front-left: 19661 /  30% / -24.61 dB ..."
+        // Strategy: find the first '%' and walk back to the start of the number.
+        const out = result.stdout;
+        const pct_idx = std.mem.indexOfScalar(u8, out, '%') orelse return null;
+        var start = pct_idx;
+        while (start > 0) {
+            const ch = out[start - 1];
+            if (ch >= '0' and ch <= '9') {
+                start -= 1;
+            } else break;
+        }
+        if (start == pct_idx) return null;
+        return std.fmt.parseInt(u32, out[start..pct_idx], 10) catch null;
+    }
+
+    pub fn interval(self: *Volume) u64 {
+        return self.interval_secs;
+    }
+
+    pub fn getColor(self: *Volume) c_ulong {
+        return self.color;
+    }
+};

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -67,6 +67,7 @@ pub const BlockType = enum {
     shell,
     battery,
     cpu_temp,
+    volume,
 };
 
 pub const ClickTarget = enum {
@@ -164,6 +165,8 @@ pub const Block = struct {
     format_full: ?[]const u8 = null,
     battery_name: ?[]const u8 = null,
     thermal_zone: ?[]const u8 = null,
+    format_muted: ?[]const u8 = null,
+    sink: ?[]const u8 = null,
     click: ?ClickAction = null,
 };
 

--- a/src/config/lua.zig
+++ b/src/config/lua.zig
@@ -294,6 +294,9 @@ fn registerBarModule(state: *c.lua_State) void {
     c.lua_pushcfunction(state, luaBarBlockBattery);
     c.lua_setfield(state, -2, "battery");
 
+    c.lua_pushcfunction(state, luaBarBlockVolume);
+    c.lua_setfield(state, -2, "volume");
+
     c.lua_setfield(state, -2, "block");
 
     c.lua_setfield(state, -2, "bar");
@@ -882,6 +885,19 @@ fn parseBlockConfig(state: *c.lua_State, idx: c_int) ?Block {
             c.lua_settop(state, -2);
         }
         c.lua_settop(state, -2);
+    } else if (std.mem.eql(u8, block_type_str, "Volume")) {
+        block.block_type = .volume;
+        _ = c.lua_getfield(state, idx, "__arg");
+        if (c.lua_type(state, -1) == c.LUA_TTABLE) {
+            _ = c.lua_getfield(state, -1, "format_muted");
+            block.format_muted = dupeLuaString(state, -1);
+            c.lua_settop(state, -2);
+
+            _ = c.lua_getfield(state, -1, "sink");
+            block.sink = dupeLuaString(state, -1);
+            c.lua_settop(state, -2);
+        }
+        c.lua_settop(state, -2);
     } else {
         return null;
     }
@@ -954,6 +970,39 @@ fn luaBarBlockStatic(state: ?*c.lua_State) callconv(.c) c_int {
     const text = getLuaString(s, -1);
     c.lua_settop(s, -2);
     createBlockTable(s, "Static", text);
+    return 1;
+}
+
+fn luaBarBlockVolume(state: ?*c.lua_State) callconv(.c) c_int {
+    const s = state orelse return 0;
+
+    c.lua_createtable(s, 0, 7);
+
+    _ = c.lua_pushstring(s, "Volume");
+    c.lua_setfield(s, -2, "__block_type");
+
+    _ = c.lua_getfield(s, 1, "format");
+    c.lua_setfield(s, -2, "format");
+
+    _ = c.lua_getfield(s, 1, "interval");
+    c.lua_setfield(s, -2, "interval");
+
+    _ = c.lua_getfield(s, 1, "color");
+    c.lua_setfield(s, -2, "color");
+
+    _ = c.lua_getfield(s, 1, "underline");
+    c.lua_setfield(s, -2, "underline");
+
+    _ = c.lua_getfield(s, 1, "click");
+    c.lua_setfield(s, -2, "click");
+
+    c.lua_createtable(s, 0, 2);
+    _ = c.lua_getfield(s, 1, "format_muted");
+    c.lua_setfield(s, -2, "format_muted");
+    _ = c.lua_getfield(s, 1, "sink");
+    c.lua_setfield(s, -2, "sink");
+    c.lua_setfield(s, -2, "__arg");
+
     return 1;
 }
 

--- a/src/wm/wm.zig
+++ b/src/wm/wm.zig
@@ -745,6 +745,14 @@ pub fn configBlockToBarBlock(cfg: config_mod.Block) blocks_mod.Block {
             cfg.color,
             cfg.underline,
         ),
+        .volume => blocks_mod.Block.initVolume(
+            cfg.format,
+            cfg.format_muted orelse "muted",
+            cfg.sink orelse "@DEFAULT_SINK@",
+            cfg.interval,
+            cfg.color,
+            cfg.underline,
+        ),
     };
     block.click = cfg.click;
     return block;


### PR DESCRIPTION
Adds a `volume` block alongside ram/battery/datetime/shell/static/cpu_temp. Polls pactl for sink volume and mute state, formats accordingly.

Lua usage:

  oxwm.bar.block.volume({
      format = "Vol: {}%",
      format_muted = "Vol: muted",
      sink = "@DEFAULT_SINK@",   -- optional, defaults to default sink
      interval = 5,
      color = colors.purple,
      underline = true,
      click = "pavucontrol",
  })

The block runs `pactl get-sink-mute <sink>` and (when not muted) `pactl get-sink-volume <sink>`, parses the percentage from the output, and substitutes into `format`. When muted, `format_muted` is used as-is (no value substitution).

Files added:
- src/bar/blocks/volume.zig: ~80-line block implementation following the battery.zig template

Files modified:
- src/bar/blocks/blocks.zig: Volume variant in BlockData union, initVolume factory, dispatch arms in update/interval/color switches
- src/config/config.zig: .volume in BlockType enum, format_muted and sink optional fields on Block
- src/config/lua.zig: luaBarBlockVolume handler, registration in registerBarModule, "Volume" parse branch in parseBlockConfig
- src/wm/wm.zig: .volume arm in configBlockToBarBlock

Pairs naturally with per-button click handlers — bind scroll_up/scroll_down to `pactl set-sink-volume +5%/-5%` and right_click to mute toggle for a fully interactive volume widget.