### PR TITLE
feat(bar): add centered focused window title display

### DIFF
--- a/hm.nix
+++ b/hm.nix
@@ -83,6 +83,8 @@
     oxwm.bar.set_scheme_selected(${concatMapStringsSep ", " (c: ''"#${c}"'') cfg.bar.selectedScheme})
     oxwm.bar.set_scheme_urgent(${concatMapStringsSep ", " (c: ''"#${c}"'') cfg.bar.urgentScheme})
     oxwm.bar.set_hide_vacant_tags(${boolToString cfg.bar.hideVacantTags})
+    oxwm.bar.set_show_title(${boolToString cfg.bar.showTitle})
+    oxwm.bar.set_max_title_length(${toString cfg.bar.maxTitleLength})
 
     oxwm.border.set_width(${toString cfg.border.width})
     oxwm.border.set_focused_color("#${cfg.border.focusedColor}")
@@ -304,6 +306,16 @@ in {
           type = types.bool;
           default = false;
           description = "Whether to hide tags with no windows from the bar";
+        };
+        showTitle = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Show the focused window title centered in the bar";
+        };
+        maxTitleLength = mkOption {
+          type = types.int;
+          default = 80;
+          description = "Maximum title length in characters (0 = no truncation)";
         };
         unoccupiedScheme = mkOption {
           type = types.listOf types.str;

--- a/src/bar/bar.zig
+++ b/src/bar/bar.zig
@@ -36,6 +36,8 @@ pub const Bar = struct {
     scheme_occupied: ColorScheme,
     scheme_urgent: ColorScheme,
     hide_vacant_tags: bool,
+    show_title: bool,
+    max_title_len: u32,
 
     allocator: std.mem.Allocator,
     blocks: std.ArrayList(Block),
@@ -130,6 +132,8 @@ pub const Bar = struct {
             .scheme_occupied = config.scheme_occupied,
             .scheme_urgent = config.scheme_urgent,
             .hide_vacant_tags = config.hide_vacant_tags,
+            .show_title = config.show_bar_title,
+            .max_title_len = config.bar_title_max_length,
             .allocator = allocator,
             .blocks = .empty,
             .needs_redraw = true,
@@ -224,6 +228,35 @@ pub const Bar = struct {
                 self.fillRect(display, block_x, self.height - 2, content_width, 2, block.color());
             }
             block_x -= padding;
+        }
+
+        if (self.show_title) {
+            const middle_right = block_x + padding;
+            const middle_width = middle_right - x_position;
+            if (middle_width > 0) {
+                if (self.monitor.sel) |sel| {
+                    var title = std.mem.sliceTo(&sel.name, 0);
+                    if (title.len > 0) {
+                        var trunc_buf: [256]u8 = undefined;
+                        if (self.max_title_len > 0 and title.len > self.max_title_len) {
+                            if (self.max_title_len >= 3) {
+                                const keep = self.max_title_len - 3;
+                                @memcpy(trunc_buf[0..keep], title[0..keep]);
+                                @memcpy(trunc_buf[keep..self.max_title_len], "...");
+                                title = trunc_buf[0..self.max_title_len];
+                            } else {
+                                title = title[0..self.max_title_len];
+                            }
+                        }
+                        const title_width = self.textWidth(display, title);
+                        if (title_width <= middle_width) {
+                            const title_x = x_position + @divTrunc(middle_width - title_width, 2);
+                            const title_y = @divTrunc(self.height + self.font_height, 2) - 4;
+                            self.drawText(display, title_x, title_y, title, self.scheme_normal.foreground);
+                        }
+                    }
+                }
+            }
         }
 
         _ = xlib.XCopyArea(display, self.pixmap, self.window, self.graphics_context, 0, 0, @intCast(self.width), @intCast(self.height), 0, 0);

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -199,6 +199,8 @@ pub const Config = struct {
     auto_tile: bool = false,
     tag_back_and_forth: bool = false,
     hide_vacant_tags: bool = false,
+    show_bar_title: bool = false,
+    bar_title_max_length: u32 = 0,
     floating_position: FloatingPosition = .center,
     tiled_resize_mode: bool = false,
 

--- a/src/config/lua.zig
+++ b/src/config/lua.zig
@@ -251,7 +251,7 @@ fn registerRuleModule(state: *c.lua_State) void {
 }
 
 fn registerBarModule(state: *c.lua_State) void {
-    c.lua_createtable(state, 0, 10);
+    c.lua_createtable(state, 0, 12);
 
     c.lua_pushcfunction(state, luaBarSetFont);
     c.lua_setfield(state, -2, "set_font");
@@ -273,6 +273,12 @@ fn registerBarModule(state: *c.lua_State) void {
 
     c.lua_pushcfunction(state, luaBarSetHideVacantTags);
     c.lua_setfield(state, -2, "set_hide_vacant_tags");
+
+    c.lua_pushcfunction(state, luaBarSetShowTitle);
+    c.lua_setfield(state, -2, "set_show_title");
+
+    c.lua_pushcfunction(state, luaBarSetMaxTitleLength);
+    c.lua_setfield(state, -2, "set_max_title_length");
 
     c.lua_pushcfunction(state, luaBarSetPosition);
     c.lua_setfield(state, -2, "set_position");
@@ -921,6 +927,20 @@ fn luaBarSetHideVacantTags(state: ?*c.lua_State) callconv(.c) c_int {
     const cfg = config orelse return 0;
     const s = state orelse return 0;
     cfg.hide_vacant_tags = c.lua_toboolean(s, 1) != 0;
+    return 0;
+}
+
+fn luaBarSetShowTitle(state: ?*c.lua_State) callconv(.c) c_int {
+    const cfg = config orelse return 0;
+    const s = state orelse return 0;
+    cfg.show_bar_title = c.lua_toboolean(s, 1) != 0;
+    return 0;
+}
+
+fn luaBarSetMaxTitleLength(state: ?*c.lua_State) callconv(.c) c_int {
+    const cfg = config orelse return 0;
+    const s = state orelse return 0;
+    cfg.bar_title_max_length = @intCast(c.lua_tointegerx(s, 1, null));
     return 0;
 }
 

--- a/src/wm/handlers.zig
+++ b/src/wm/handlers.zig
@@ -383,6 +383,7 @@ fn handlePropertyNotify(event: *xlib.XPropertyEvent, wm: *WindowManager) void {
         wm.invalidateBars();
     } else if (event.atom == xlib.XA_WM_NAME or event.atom == wm.atoms.net_wm_name) {
         core.updateTitle(client, wm);
+        wm.invalidateBars();
     } else if (event.atom == wm.atoms.net_wm_window_type) {
         core.updateWindowType(client, wm);
     }


### PR DESCRIPTION
Adds support for showing the currently focused window title centered in the bar, between the layout symbol (left) and status blocks (right).

**Changes:**
- Config: add `show_bar_title` (bool, default false) and `bar_title_max_length` (u32, default 0)
- Lua API: `oxwm.bar.set_show_title(bool)` and `oxwm.bar.set_max_title_length(uint)`
- Bar drawing: compute middle gap between layout symbol and blocks, read focused client name from `monitor.sel`, center text, truncate with `...` if over max length
- Event handler: invalidate bars on WM_NAME / _NET_WM_NAME change so title updates are reflected immediately
- hm.nix: add `showTitle` (default false) and `maxTitleLength` (default 80) options to the bar submodule

**Drawing order:** bar body → tags → layout symbol → blocks → title.

**Truncation:** `max_length=0` means no limit, `>=3` adds `...` suffix, `<3` hard truncates.

**Backward compatible:** default `show_bar_title=false` means no behavioral change.