### PR TITLE
fix(hm.nix): correct gaps.smart type from enum to bool

### DIFF
--- a/hm.nix
+++ b/hm.nix
@@ -88,7 +88,7 @@
     oxwm.border.set_focused_color("#${cfg.border.focusedColor}")
     oxwm.border.set_unfocused_color("#${cfg.border.unfocusedColor}")
 
-    oxwm.gaps.set_smart(${cfg.gaps.smart})
+    oxwm.gaps.set_smart(${boolToString cfg.gaps.smart})
     oxwm.gaps.set_inner(${concatMapStringsSep ", " toString cfg.gaps.inner})
     oxwm.gaps.set_outer(${concatMapStringsSep ", " toString cfg.gaps.outer})
 
@@ -279,8 +279,8 @@ in {
       };
       gaps = {
         smart = mkOption {
-          type = types.enum ["enabled" "disabled"];
-          default = "enabled";
+          type = types.bool;
+          default = true;
           description = "If enabled, removes border if single window in tag";
         };
         inner = mkOption {


### PR DESCRIPTION
The `gaps.smart` option was incorrectly typed as `types.enum ["enabled" "disabled"]`, but OXWM's Lua API `oxwm.gaps.set_smart` expects a boolean argument.

**Changes:**
- Type: `types.enum ["enabled" "disabled"]` → `types.bool`
- Default: `"enabled"` → `true`
- Lua generation: interpolate raw string → `boolToString` (produces valid `true` / `false` literals)

This aligns the Home Manager module with the actual `lua_toboolean`-based Lua API.