### PR TITLE
feat(bar): add per-block and per-tag background color support

### DIFF
--- a/hm.nix
+++ b/hm.nix
@@ -4,7 +4,7 @@
   pkgs,
   ...
 }: let
-  inherit (lib) mkEnableOption mkOption mkIf types concatMapStringsSep concatStringsSep concatMapStrings boolToString optional;
+  inherit (lib) mkEnableOption mkOption mkIf types concatMapStringsSep concatStringsSep concatMapStrings boolToString optional optionalString;
   inherit (lib.strings) escapeNixString;
   cfg = config.programs.oxwm.settings;
   pkg = config.programs.oxwm.package;
@@ -14,6 +14,7 @@
     common = ''
       interval = ${toString block.interval},
       color = "#${block.color}",
+      ${optionalString (block.bg != "") ''bg = "#${block.bg}",''}
       underline = ${boolToString block.underline},
     '';
   in
@@ -340,6 +341,11 @@ in {
               color = mkOption {
                 type = types.str;
                 default = "";
+              };
+              bg = mkOption {
+                type = types.str;
+                default = "";
+                description = "Optional background color for the block (hex without #). Empty means no background.";
               };
               underline = mkOption {
                 type = types.bool;

--- a/src/bar/bar.zig
+++ b/src/bar/bar.zig
@@ -194,6 +194,8 @@ pub const Bar = struct {
             const tag_text_width = self.textWidth(display, tag);
             const tag_width = tag_text_width + padding * 2;
 
+            self.fillRect(display, x_position, 0, tag_width, self.height, scheme.background);
+
             if (is_selected) {
                 self.fillRect(display, x_position, self.height - 3, tag_width, 3, scheme.border);
             }
@@ -219,6 +221,9 @@ pub const Bar = struct {
             block_x -= content_width;
             block.x_start = block_x;
             block.x_end = block_x + content_width;
+            if (block.bg() != 0) {
+                self.fillRect(display, block_x, 0, content_width, self.height, block.bg());
+            }
             self.drawText(display, block_x, @divTrunc(self.height + self.font_height, 2) - 4, content, block.color());
             if (block.underline) {
                 self.fillRect(display, block_x, self.height - 2, content_width, 2, block.color());

--- a/src/bar/blocks/battery.zig
+++ b/src/bar/blocks/battery.zig
@@ -8,6 +8,7 @@ pub const Battery = struct {
     battery_name: []const u8,
     interval_secs: u64,
     color: c_ulong,
+    bg: c_ulong,
 
     pub fn init(
         format_charging: []const u8,
@@ -16,6 +17,7 @@ pub const Battery = struct {
         battery_name: []const u8,
         interval_secs: u64,
         color: c_ulong,
+        background: c_ulong,
     ) Battery {
         return .{
             .format_charging = format_charging,
@@ -24,6 +26,7 @@ pub const Battery = struct {
             .battery_name = if (battery_name.len > 0) battery_name else "BAT0",
             .interval_secs = interval_secs,
             .color = color,
+            .bg = background,
         };
     }
 

--- a/src/bar/blocks/blocks.zig
+++ b/src/bar/blocks/blocks.zig
@@ -27,9 +27,9 @@ pub const Block = struct {
         cpu_temp: CpuTemp,
     };
 
-    pub fn initStatic(text: []const u8, col: c_ulong, ul: bool) Block {
+    pub fn initStatic(text: []const u8, col: c_ulong, background: c_ulong, ul: bool) Block {
         var block = Block{
-            .data = .{ .static = Static.init(text, col) },
+            .data = .{ .static = Static.init(text, col, background) },
             .last_update = 0,
             .cached_content = undefined,
             .cached_len = 0,
@@ -40,9 +40,9 @@ pub const Block = struct {
         return block;
     }
 
-    pub fn initDatetime(format: []const u8, datetime_format: []const u8, interval_secs: u64, col: c_ulong, ul: bool) Block {
+    pub fn initDatetime(format: []const u8, datetime_format: []const u8, interval_secs: u64, col: c_ulong, background: c_ulong, ul: bool) Block {
         return .{
-            .data = .{ .datetime = DateTime.init(format, datetime_format, interval_secs, col) },
+            .data = .{ .datetime = DateTime.init(format, datetime_format, interval_secs, col, background) },
             .last_update = 0,
             .cached_content = undefined,
             .cached_len = 0,
@@ -50,9 +50,9 @@ pub const Block = struct {
         };
     }
 
-    pub fn initRam(format: []const u8, interval_secs: u64, col: c_ulong, ul: bool) Block {
+    pub fn initRam(format: []const u8, interval_secs: u64, col: c_ulong, background: c_ulong, ul: bool) Block {
         return .{
-            .data = .{ .ram = Ram.init(format, interval_secs, col) },
+            .data = .{ .ram = Ram.init(format, interval_secs, col, background) },
             .last_update = 0,
             .cached_content = undefined,
             .cached_len = 0,
@@ -60,9 +60,9 @@ pub const Block = struct {
         };
     }
 
-    pub fn initShell(format: []const u8, command: []const u8, interval_secs: u64, col: c_ulong, ul: bool) Block {
+    pub fn initShell(format: []const u8, command: []const u8, interval_secs: u64, col: c_ulong, background: c_ulong, ul: bool) Block {
         return .{
-            .data = .{ .shell = Shell.init(format, command, interval_secs, col) },
+            .data = .{ .shell = Shell.init(format, command, interval_secs, col, background) },
             .last_update = 0,
             .cached_content = undefined,
             .cached_len = 0,
@@ -77,10 +77,11 @@ pub const Block = struct {
         battery_name: []const u8,
         interval_secs: u64,
         col: c_ulong,
+        background: c_ulong,
         ul: bool,
     ) Block {
         return .{
-            .data = .{ .battery = Battery.init(format_charging, format_discharging, format_full, battery_name, interval_secs, col) },
+            .data = .{ .battery = Battery.init(format_charging, format_discharging, format_full, battery_name, interval_secs, col, background) },
             .last_update = 0,
             .cached_content = undefined,
             .cached_len = 0,
@@ -93,10 +94,11 @@ pub const Block = struct {
         thermal_zone: []const u8,
         interval_secs: u64,
         col: c_ulong,
+        background: c_ulong,
         ul: bool,
     ) Block {
         return .{
-            .data = .{ .cpu_temp = CpuTemp.init(format, thermal_zone, interval_secs, col) },
+            .data = .{ .cpu_temp = CpuTemp.init(format, thermal_zone, interval_secs, col, background) },
             .last_update = 0,
             .cached_content = undefined,
             .cached_len = 0,
@@ -147,6 +149,17 @@ pub const Block = struct {
             .shell => |s| s.color,
             .battery => |b| b.color,
             .cpu_temp => |c| c.color,
+        };
+    }
+
+    pub fn bg(self: *const Block) c_ulong {
+        return switch (self.data) {
+            .static => |s| s.bg,
+            .datetime => |d| d.bg,
+            .ram => |r| r.bg,
+            .shell => |s| s.bg,
+            .battery => |b| b.bg,
+            .cpu_temp => |c| c.bg,
         };
     }
 

--- a/src/bar/blocks/cpu_temp.zig
+++ b/src/bar/blocks/cpu_temp.zig
@@ -6,6 +6,7 @@ pub const CpuTemp = struct {
     device: []const u8,
     interval_secs: u64,
     color: c_ulong,
+    bg: c_ulong,
     cached_path: [128]u8,
     cached_path_len: usize,
 
@@ -14,12 +15,14 @@ pub const CpuTemp = struct {
         device: []const u8,
         interval_secs: u64,
         color: c_ulong,
+        background: c_ulong,
     ) CpuTemp {
         var self = CpuTemp{
             .format = format,
             .device = device,
             .interval_secs = interval_secs,
             .color = color,
+            .bg = background,
             .cached_path = undefined,
             .cached_path_len = 0,
         };

--- a/src/bar/blocks/datetime.zig
+++ b/src/bar/blocks/datetime.zig
@@ -9,13 +9,15 @@ pub const DateTime = struct {
     datetime_format: []const u8,
     interval_secs: u64,
     color: c_ulong,
+    bg: c_ulong,
 
-    pub fn init(format: []const u8, datetime_format: []const u8, interval_secs: u64, color: c_ulong) DateTime {
+    pub fn init(format: []const u8, datetime_format: []const u8, interval_secs: u64, color: c_ulong, background: c_ulong) DateTime {
         return .{
             .format = format,
             .datetime_format = datetime_format,
             .interval_secs = interval_secs,
             .color = color,
+            .bg = background,
         };
     }
 

--- a/src/bar/blocks/ram.zig
+++ b/src/bar/blocks/ram.zig
@@ -4,12 +4,14 @@ pub const Ram = struct {
     format: []const u8,
     interval_secs: u64,
     color: c_ulong,
+    bg: c_ulong,
 
-    pub fn init(format: []const u8, interval_secs: u64, color: c_ulong) Ram {
+    pub fn init(format: []const u8, interval_secs: u64, color: c_ulong, background: c_ulong) Ram {
         return .{
             .format = format,
             .interval_secs = interval_secs,
             .color = color,
+            .bg = background,
         };
     }
 

--- a/src/bar/blocks/shell.zig
+++ b/src/bar/blocks/shell.zig
@@ -6,13 +6,15 @@ pub const Shell = struct {
     command: []const u8,
     interval_secs: u64,
     color: c_ulong,
+    bg: c_ulong,
 
-    pub fn init(format: []const u8, command: []const u8, interval_secs: u64, col: c_ulong) Shell {
+    pub fn init(format: []const u8, command: []const u8, interval_secs: u64, col: c_ulong, background: c_ulong) Shell {
         return .{
             .format = format,
             .command = command,
             .interval_secs = interval_secs,
             .color = col,
+            .bg = background,
         };
     }
 

--- a/src/bar/blocks/static.zig
+++ b/src/bar/blocks/static.zig
@@ -3,9 +3,10 @@ const std = @import("std");
 pub const Static = struct {
     text: []const u8,
     color: c_ulong,
+    bg: c_ulong,
 
-    pub fn init(text: []const u8, color: c_ulong) Static {
-        return .{ .text = text, .color = color };
+    pub fn init(text: []const u8, color: c_ulong, background: c_ulong) Static {
+        return .{ .text = text, .color = color, .bg = background };
     }
 
     pub fn content(self: *Static, buffer: []u8) []const u8 {

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -157,6 +157,7 @@ pub const Block = struct {
     command: ?[]const u8 = null,
     interval: u32,
     color: u32,
+    bg: u32 = 0,
     underline: bool = true,
     datetime_format: ?[]const u8 = null,
     format_charging: ?[]const u8 = null,

--- a/src/config/lua.zig
+++ b/src/config/lua.zig
@@ -825,6 +825,10 @@ fn parseBlockConfig(state: *c.lua_State, idx: c_int) ?Block {
     const color = parseColor(state, -1);
     c.lua_settop(state, -2);
 
+    _ = c.lua_getfield(state, idx, "bg");
+    const bg = parseColor(state, -1);
+    c.lua_settop(state, -2);
+
     _ = c.lua_getfield(state, idx, "underline");
     const underline = c.lua_toboolean(state, -1) != 0;
     c.lua_settop(state, -2);
@@ -838,6 +842,7 @@ fn parseBlockConfig(state: *c.lua_State, idx: c_int) ?Block {
         .format = format,
         .interval = interval,
         .color = color,
+        .bg = bg,
         .underline = underline,
         .click = click,
     };
@@ -974,6 +979,9 @@ fn luaBarBlockBattery(state: ?*c.lua_State) callconv(.c) c_int {
     _ = c.lua_getfield(s, 1, "color");
     c.lua_setfield(s, -2, "color");
 
+    _ = c.lua_getfield(s, 1, "bg");
+    c.lua_setfield(s, -2, "bg");
+
     _ = c.lua_getfield(s, 1, "underline");
     c.lua_setfield(s, -2, "underline");
 
@@ -1008,6 +1016,9 @@ fn createBlockTable(state: *c.lua_State, block_type: [*:0]const u8, arg: ?[]cons
 
     _ = c.lua_getfield(state, 1, "color");
     c.lua_setfield(state, -2, "color");
+
+    _ = c.lua_getfield(state, 1, "bg");
+    c.lua_setfield(state, -2, "bg");
 
     _ = c.lua_getfield(state, 1, "underline");
     c.lua_setfield(state, -2, "underline");

--- a/src/wm/wm.zig
+++ b/src/wm/wm.zig
@@ -456,9 +456,9 @@ pub const WindowManager = struct {
                 bar.addBlock(configBlockToBarBlock(cfg_block));
             }
         } else {
-            bar.addBlock(blocks_mod.Block.initRam("", 5, 0x7aa2f7, true));
-            bar.addBlock(blocks_mod.Block.initStatic(" | ", 0x666666, false));
-            bar.addBlock(blocks_mod.Block.initDatetime("", "%H:%M", 1, 0x0db9d7, true));
+            bar.addBlock(blocks_mod.Block.initRam("", 5, 0x7aa2f7, 0, true));
+            bar.addBlock(blocks_mod.Block.initStatic(" | ", 0x666666, 0, false));
+            bar.addBlock(blocks_mod.Block.initDatetime("", "%H:%M", 1, 0x0db9d7, 0, true));
         }
     }
 
@@ -713,20 +713,22 @@ pub const WindowManager = struct {
 /// Converts a config block description into a live status bar block.
 pub fn configBlockToBarBlock(cfg: config_mod.Block) blocks_mod.Block {
     var block = switch (cfg.block_type) {
-        .static => blocks_mod.Block.initStatic(cfg.format, cfg.color, cfg.underline),
+        .static => blocks_mod.Block.initStatic(cfg.format, cfg.color, cfg.bg, cfg.underline),
         .datetime => blocks_mod.Block.initDatetime(
             cfg.format,
             cfg.datetime_format orelse "%H:%M",
             cfg.interval,
             cfg.color,
+            cfg.bg,
             cfg.underline,
         ),
-        .ram => blocks_mod.Block.initRam(cfg.format, cfg.interval, cfg.color, cfg.underline),
+        .ram => blocks_mod.Block.initRam(cfg.format, cfg.interval, cfg.color, cfg.bg, cfg.underline),
         .shell => blocks_mod.Block.initShell(
             cfg.format,
             cfg.command orelse "",
             cfg.interval,
             cfg.color,
+            cfg.bg,
             cfg.underline,
         ),
         .battery => blocks_mod.Block.initBattery(
@@ -736,6 +738,7 @@ pub fn configBlockToBarBlock(cfg: config_mod.Block) blocks_mod.Block {
             cfg.battery_name orelse "BAT0",
             cfg.interval,
             cfg.color,
+            cfg.bg,
             cfg.underline,
         ),
         .cpu_temp => blocks_mod.Block.initCpuTemp(
@@ -743,6 +746,7 @@ pub fn configBlockToBarBlock(cfg: config_mod.Block) blocks_mod.Block {
             cfg.thermal_zone orelse "thermal_zone0",
             cfg.interval,
             cfg.color,
+            cfg.bg,
             cfg.underline,
         ),
     };


### PR DESCRIPTION
Previously bar blocks only accepted a single `color` field used for both foreground text and underline. Tags had per-scheme `background` values in the config struct but they were never rendered.

**Changes:**
- Config Block: add `bg: u32 = 0` field (0 = no background)
- All 6 block type structs: add `bg` field + updated `init()`
- blocks.zig wrapper: add `bg()` dispatch, updated all `init*` signatures
- wm.zig: pass `cfg.bg` through `configBlockToBarBlock`
- lua.zig: parse `bg` from Lua block tables + copy it in constructors
- bar.zig draw(): fill per-tag background using `scheme.background`, fill per-block background using `block.bg()` when non-zero
- hm.nix: add `bg` option to block submodule, conditionally emit `bg` in generated Lua

**Drawing order:** background fill → text → underline, symmetric for both tags and blocks.

**Backward compatible:** default `bg = 0` means no background drawn.

**Lua usage:**
```lua
oxwm.bar.block.ram({
    format = "RAM: {used}/{total} GB",
    color = "#7aa2f7",
    bg = "#1a3a3a", 
    underline = true
})
```