### PR TITLE
Systray (oxwm is becoming a DE at this point)

### DIFF
--- a/src/bar/bar.zig
+++ b/src/bar/bar.zig
@@ -44,6 +44,8 @@ pub const Bar = struct {
     needs_redraw: bool,
     next: ?*Bar,
     systray: ?*Systray,
+    systray_underline: bool,
+    systray_color: u32,
 
     /// Creates a bar window for `monitor` using the given config.
     /// Returns null on allocation failure or if the font cannot be loaded.
@@ -145,6 +147,8 @@ pub const Bar = struct {
             .needs_redraw = true,
             .next = null,
             .systray = systray,
+            .systray_underline = false,
+            .systray_color = 0xffffff,
         };
 
         monitor.bar_win = window;
@@ -169,6 +173,11 @@ pub const Bar = struct {
 
     pub fn addBlock(self: *Bar, block: Block) void {
         self.blocks.append(self.allocator, block) catch {};
+    }
+
+    pub fn setSystrayConfig(self: *Bar, underline: bool, col: u32) void {
+        self.systray_underline = underline;
+        self.systray_color = col;
     }
 
     pub fn clearBlocks(self: *Bar) void {
@@ -243,7 +252,11 @@ pub const Bar = struct {
         }
 
         if (self.systray) |tray| {
-            tray.updatePosition(self.width - systray_width - padding, 0);
+            const systray_x = self.width - systray_width - padding;
+            tray.updatePosition(systray_x, 0);
+            if (self.systray_underline and systray_width > 0) {
+                self.fillRect(display, systray_x, self.height - 2, systray_width, 2, self.systray_color);
+            }
         }
 
         _ = xlib.XCopyArea(display, self.pixmap, self.window, self.graphics_context, 0, 0, @intCast(self.width), @intCast(self.height), 0, 0);

--- a/src/bar/bar.zig
+++ b/src/bar/bar.zig
@@ -44,6 +44,8 @@ pub const Bar = struct {
     needs_redraw: bool,
     next: ?*Bar,
     systray: ?*Systray,
+    systray_underline: bool,
+    systray_color: u32,
 
     /// Creates a bar window for `monitor` using the given config.
     /// Returns null on allocation failure or if the font cannot be loaded.
@@ -133,6 +135,8 @@ pub const Bar = struct {
             .needs_redraw = true,
             .next = null,
             .systray = systray,
+            .systray_underline = false,
+            .systray_color = 0xffffff,
         };
 
         monitor.bar_win = window;
@@ -158,6 +162,11 @@ pub const Bar = struct {
 
     pub fn addBlock(self: *Bar, block: Block) void {
         self.blocks.append(self.allocator, block) catch {};
+    }
+
+    pub fn setSystrayConfig(self: *Bar, underline: bool, col: u32) void {
+        self.systray_underline = underline;
+        self.systray_color = col;
     }
 
     pub fn clearBlocks(self: *Bar) void {
@@ -230,7 +239,11 @@ pub const Bar = struct {
         }
 
         if (self.systray) |tray| {
-            tray.updatePosition(self.width - systray_width - padding, 0);
+            const systray_x = self.width - systray_width - padding;
+            tray.updatePosition(systray_x, 0);
+            if (self.systray_underline and systray_width > 0) {
+                self.fillRect(display, systray_x, self.height - 2, systray_width, 2, self.systray_color);
+            }
         }
 
         _ = xlib.XCopyArea(display, self.pixmap, self.window, self.graphics_context, 0, 0, @intCast(self.width), @intCast(self.height), 0, 0);

--- a/src/bar/bar.zig
+++ b/src/bar/bar.zig
@@ -3,10 +3,12 @@ const xlib = @import("../x11/xlib.zig");
 const monitor_mod = @import("../monitor.zig");
 const blocks_mod = @import("blocks/blocks.zig");
 const config_mod = @import("../config/config.zig");
+const systray_mod = @import("systray.zig");
 const ColorScheme = config_mod.ColorScheme;
 
 const Monitor = monitor_mod.Monitor;
 const Block = blocks_mod.Block;
+pub const Systray = systray_mod.Systray;
 
 fn getLayoutSymbol(layout_index: u32, config: config_mod.Config) []const u8 {
     return switch (layout_index) {
@@ -41,15 +43,18 @@ pub const Bar = struct {
     blocks: std.ArrayList(Block),
     needs_redraw: bool,
     next: ?*Bar,
+    systray: ?*Systray,
 
     /// Creates a bar window for `monitor` using the given config.
     /// Returns null on allocation failure or if the font cannot be loaded.
+    /// If `with_systray` is true, this bar will host the system tray.
     pub fn create(
         allocator: std.mem.Allocator,
         display: *xlib.Display,
         screen: c_int,
         monitor: *Monitor,
         config: config_mod.Config,
+        with_systray: bool,
     ) ?*Bar {
         const bar = allocator.create(Bar) catch return null;
 
@@ -103,6 +108,11 @@ pub const Bar = struct {
 
         _ = xlib.XMapWindow(display, window);
 
+        const systray: ?*Systray = if (with_systray)
+            Systray.init(allocator, display, screen, window, bar_height, config.scheme_normal.background)
+        else
+            null;
+
         bar.* = Bar{
             .window = window,
             .pixmap = pixmap,
@@ -122,6 +132,7 @@ pub const Bar = struct {
             .blocks = .empty,
             .needs_redraw = true,
             .next = null,
+            .systray = systray,
         };
 
         monitor.bar_win = window;
@@ -133,6 +144,8 @@ pub const Bar = struct {
 
     /// Destroys the bar's X resources and frees the allocation.
     pub fn destroy(self: *Bar, display: *xlib.Display) void {
+        if (self.systray) |tray| tray.deinit();
+
         if (self.xft_draw) |xft_draw| xlib.XftDrawDestroy(xft_draw);
         if (self.font) |font| xlib.XftFontClose(display, font);
 
@@ -198,7 +211,10 @@ pub const Bar = struct {
         self.drawText(display, x_position, @divTrunc(self.height + self.font_height, 2) - 4, layout_symbol, self.scheme_normal.foreground);
         x_position += self.textWidth(display, layout_symbol) + padding;
 
-        var block_x: i32 = self.width - padding;
+        const systray_width: i32 = if (self.systray) |tray| tray.width() else 0;
+        var block_x: i32 = self.width - padding - systray_width;
+        if (systray_width > 0) block_x -= padding;
+
         var block_index: usize = self.blocks.items.len;
         while (block_index > 0) {
             block_index -= 1;
@@ -211,6 +227,10 @@ pub const Bar = struct {
                 self.fillRect(display, block_x, self.height - 2, content_width, 2, block.color());
             }
             block_x -= padding;
+        }
+
+        if (self.systray) |tray| {
+            tray.updatePosition(self.width - systray_width - padding, 0);
         }
 
         _ = xlib.XCopyArea(display, self.pixmap, self.window, self.graphics_context, 0, 0, @intCast(self.width), @intCast(self.height), 0, 0);
@@ -324,4 +344,13 @@ fn hasClientsOnTag(monitor: *Monitor, tag_mask: u32) bool {
         current = client.next;
     }
     return false;
+}
+
+pub fn getSystray(bars: ?*Bar) ?*Systray {
+    var current = bars;
+    while (current) |bar| {
+        if (bar.systray) |tray| return tray;
+        current = bar.next;
+    }
+    return null;
 }

--- a/src/bar/bar.zig
+++ b/src/bar/bar.zig
@@ -3,10 +3,12 @@ const xlib = @import("../x11/xlib.zig");
 const monitor_mod = @import("../monitor.zig");
 const blocks_mod = @import("blocks/blocks.zig");
 const config_mod = @import("../config/config.zig");
+const systray_mod = @import("systray.zig");
 const ColorScheme = config_mod.ColorScheme;
 
 const Monitor = monitor_mod.Monitor;
 const Block = blocks_mod.Block;
+pub const Systray = systray_mod.Systray;
 
 fn getLayoutSymbol(layout_index: u32, config: config_mod.Config) []const u8 {
     const layout = std.meta.intToEnum(config_mod.Layouts, layout_index) catch return "[?]";
@@ -41,15 +43,18 @@ pub const Bar = struct {
     blocks: std.ArrayList(Block),
     needs_redraw: bool,
     next: ?*Bar,
+    systray: ?*Systray,
 
     /// Creates a bar window for `monitor` using the given config.
     /// Returns null on allocation failure or if the font cannot be loaded.
+    /// If `with_systray` is true, this bar will host the system tray.
     pub fn create(
         allocator: std.mem.Allocator,
         display: *xlib.Display,
         screen: c_int,
         monitor: *Monitor,
         config: config_mod.Config,
+        with_systray: bool,
     ) ?*Bar {
         const bar = allocator.create(Bar) catch return null;
 
@@ -115,6 +120,11 @@ pub const Bar = struct {
 
         _ = xlib.XMapWindow(display, window);
 
+        const systray: ?*Systray = if (with_systray)
+            Systray.init(allocator, display, screen, window, bar_height, config.scheme_normal.background)
+        else
+            null;
+
         bar.* = Bar{
             .window = window,
             .pixmap = pixmap,
@@ -134,6 +144,7 @@ pub const Bar = struct {
             .blocks = .empty,
             .needs_redraw = true,
             .next = null,
+            .systray = systray,
         };
 
         monitor.bar_win = window;
@@ -144,6 +155,8 @@ pub const Bar = struct {
 
     /// Destroys the bar's X resources and frees the allocation.
     pub fn destroy(self: *Bar, display: *xlib.Display) void {
+        if (self.systray) |tray| tray.deinit();
+
         if (self.xft_draw) |xft_draw| xlib.XftDrawDestroy(xft_draw);
         if (self.font) |font| xlib.XftFontClose(display, font);
 
@@ -209,7 +222,10 @@ pub const Bar = struct {
         self.drawText(display, x_position, @divTrunc(self.height + self.font_height, 2) - 4, layout_symbol, self.scheme_normal.foreground);
         x_position += self.textWidth(display, layout_symbol) + padding;
 
-        var block_x: i32 = self.width - padding;
+        const systray_width: i32 = if (self.systray) |tray| tray.width() else 0;
+        var block_x: i32 = self.width - padding - systray_width;
+        if (systray_width > 0) block_x -= padding;
+
         var block_index: usize = self.blocks.items.len;
         while (block_index > 0) {
             block_index -= 1;
@@ -224,6 +240,10 @@ pub const Bar = struct {
                 self.fillRect(display, block_x, self.height - 2, content_width, 2, block.color());
             }
             block_x -= padding;
+        }
+
+        if (self.systray) |tray| {
+            tray.updatePosition(self.width - systray_width - padding, 0);
         }
 
         _ = xlib.XCopyArea(display, self.pixmap, self.window, self.graphics_context, 0, 0, @intCast(self.width), @intCast(self.height), 0, 0);
@@ -347,4 +367,13 @@ fn hasClientsOnTag(monitor: *Monitor, tag_mask: u32) bool {
         current = client.next;
     }
     return false;
+}
+
+pub fn getSystray(bars: ?*Bar) ?*Systray {
+    var current = bars;
+    while (current) |bar| {
+        if (bar.systray) |tray| return tray;
+        current = bar.next;
+    }
+    return null;
 }

--- a/src/bar/systray.zig
+++ b/src/bar/systray.zig
@@ -82,7 +82,7 @@ pub const Systray = struct {
             0,
             0,
             1,
-            @intCast(bar_height),
+            @intCast(bar_height - 2),
             0,
             0,
             0,
@@ -418,7 +418,7 @@ pub const Systray = struct {
         }
 
         const total_width: u32 = if (x > 0) @intCast(x) else 1;
-        _ = xlib.c.XResizeWindow(self.display, self.window, total_width, @intCast(self.bar_height));
+        _ = xlib.c.XResizeWindow(self.display, self.window, total_width, @intCast(self.bar_height - 2));
         _ = xlib.XSync(self.display, xlib.False);
     }
 

--- a/src/bar/systray.zig
+++ b/src/bar/systray.zig
@@ -56,7 +56,7 @@ pub const Systray = struct {
         self.display = display;
         self.screen = screen;
         self.bar_height = bar_height;
-        self.icon_size = bar_height - 4;
+        self.icon_size = bar_height - 8;
         self.icons = .empty;
 
         self.net_system_tray_opcode = xlib.XInternAtom(display, "_NET_SYSTEM_TRAY_OPCODE", xlib.False);
@@ -449,5 +449,80 @@ pub const Systray = struct {
             if (icon.window == win) return true;
         }
         return false;
+    }
+
+    pub fn handleButtonPress(self: *Systray, ev: *xlib.XButtonEvent) bool {
+        if (ev.window != self.window) {
+            for (self.icons.items) |icon| {
+                if (icon.window == ev.window) {
+                    self.sendButtonEvent(icon.window, ev, true);
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        const spacing: i32 = 4;
+        var x: i32 = 0;
+        for (self.icons.items) |icon| {
+            if (icon.mapped) {
+                if (ev.x >= x and ev.x < x + icon.width) {
+                    self.sendButtonEvent(icon.window, ev, true);
+                    return true;
+                }
+                x += icon.width + spacing;
+            }
+        }
+        return false;
+    }
+
+    pub fn handleButtonRelease(self: *Systray, ev: *xlib.XButtonEvent) bool {
+        if (ev.window != self.window) {
+            for (self.icons.items) |icon| {
+                if (icon.window == ev.window) {
+                    self.sendButtonEvent(icon.window, ev, false);
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        const spacing: i32 = 4;
+        var x: i32 = 0;
+        for (self.icons.items) |icon| {
+            if (icon.mapped) {
+                if (ev.x >= x and ev.x < x + icon.width) {
+                    self.sendButtonEvent(icon.window, ev, false);
+                    return true;
+                }
+                x += icon.width + spacing;
+            }
+        }
+        return false;
+    }
+
+    fn sendButtonEvent(self: *Systray, win: xlib.Window, ev: *xlib.XButtonEvent, is_press: bool) void {
+        var event: xlib.c.XButtonEvent = undefined;
+        event.type = if (is_press) xlib.ButtonPress else xlib.ButtonRelease;
+        event.window = win;
+        event.root = xlib.XRootWindow(self.display, self.screen);
+        event.subwindow = xlib.None;
+        event.time = ev.time;
+        event.x = ev.x;
+        event.y = ev.y;
+        event.x_root = ev.x_root;
+        event.y_root = ev.y_root;
+        event.state = ev.state;
+        event.button = ev.button;
+        event.same_screen = xlib.True;
+
+        _ = xlib.XSendEvent(
+            self.display,
+            win,
+            xlib.False,
+            xlib.c.ButtonPressMask | xlib.c.ButtonReleaseMask,
+            @ptrCast(&event),
+        );
+        _ = xlib.XSync(self.display, xlib.False);
     }
 };

--- a/src/bar/systray.zig
+++ b/src/bar/systray.zig
@@ -72,7 +72,6 @@ pub const Systray = struct {
 
         const current_owner = xlib.c.XGetSelectionOwner(display, self.manager_atom);
         if (current_owner != xlib.None) {
-            std.debug.print("systray: another systray is already running\n", .{});
             allocator.destroy(self);
             return null;
         }
@@ -102,7 +101,6 @@ pub const Systray = struct {
 
         _ = xlib.c.XSetSelectionOwner(display, self.manager_atom, self.window, xlib.CurrentTime);
         if (xlib.c.XGetSelectionOwner(display, self.manager_atom) != self.window) {
-            std.debug.print("systray: failed to acquire selection ownership\n", .{});
             _ = xlib.c.XDestroyWindow(display, self.window);
             allocator.destroy(self);
             return null;
@@ -125,7 +123,6 @@ pub const Systray = struct {
         _ = xlib.XMapWindow(display, self.window);
         _ = xlib.XSync(display, xlib.False);
 
-        std.debug.print("systray: initialized on screen {d}\n", .{screen});
         return self;
     }
 
@@ -272,7 +269,6 @@ pub const Systray = struct {
 
         var wa: xlib.XWindowAttributes = undefined;
         if (xlib.XGetWindowAttributes(self.display, icon_win, &wa) == 0) {
-            std.debug.print("systray: failed to get window attributes for icon 0x{x}\n", .{icon_win});
             return;
         }
 
@@ -315,7 +311,6 @@ pub const Systray = struct {
         }
 
         self.arrangeIcons();
-        std.debug.print("systray: docked icon 0x{x} (size {}x{})\n", .{ icon_win, icon.width, icon.height });
     }
 
     pub fn handleConfigureRequest(self: *Systray, ev: *xlib.XConfigureRequestEvent) bool {
@@ -403,7 +398,6 @@ pub const Systray = struct {
             if (icon.window == win) {
                 _ = self.icons.orderedRemove(i);
                 self.arrangeIcons();
-                std.debug.print("systray: removed icon 0x{x}\n", .{win});
                 return true;
             }
         }

--- a/src/bar/systray.zig
+++ b/src/bar/systray.zig
@@ -1,0 +1,453 @@
+const std = @import("std");
+const xlib = @import("../x11/xlib.zig");
+
+pub const SYSTEM_TRAY_REQUEST_DOCK: c_long = 0;
+pub const SYSTEM_TRAY_BEGIN_MESSAGE: c_long = 1;
+pub const SYSTEM_TRAY_CANCEL_MESSAGE: c_long = 2;
+
+pub const XEMBED_EMBEDDED_NOTIFY: c_long = 0;
+pub const XEMBED_WINDOW_ACTIVATE: c_long = 1;
+pub const XEMBED_WINDOW_DEACTIVATE: c_long = 2;
+pub const XEMBED_REQUEST_FOCUS: c_long = 3;
+pub const XEMBED_FOCUS_IN: c_long = 4;
+pub const XEMBED_FOCUS_OUT: c_long = 5;
+pub const XEMBED_FOCUS_NEXT: c_long = 6;
+pub const XEMBED_FOCUS_PREV: c_long = 7;
+pub const XEMBED_MAPPED: c_ulong = 1 << 0;
+
+pub const XEMBED_VERSION: c_long = 0;
+
+pub const Icon = struct {
+    window: xlib.Window,
+    width: i32,
+    height: i32,
+    mapped: bool,
+};
+
+pub const Systray = struct {
+    window: xlib.Window,
+    icons: std.ArrayList(Icon),
+    allocator: std.mem.Allocator,
+    display: *xlib.Display,
+    screen: c_int,
+    icon_size: i32,
+    bar_height: i32,
+
+    net_system_tray_opcode: xlib.Atom,
+    net_system_tray_orientation: xlib.Atom,
+    net_system_tray_visual: xlib.Atom,
+    manager_atom: xlib.Atom,
+    xembed: xlib.Atom,
+    xembed_info: xlib.Atom,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        display: *xlib.Display,
+        screen: c_int,
+        bar_win: xlib.Window,
+        bar_height: i32,
+        background: u32,
+    ) ?*Systray {
+        const self = allocator.create(Systray) catch return null;
+
+        const root = xlib.XRootWindow(display, screen);
+
+        self.allocator = allocator;
+        self.display = display;
+        self.screen = screen;
+        self.bar_height = bar_height;
+        self.icon_size = bar_height - 4;
+        self.icons = .empty;
+
+        self.net_system_tray_opcode = xlib.XInternAtom(display, "_NET_SYSTEM_TRAY_OPCODE", xlib.False);
+        self.net_system_tray_orientation = xlib.XInternAtom(display, "_NET_SYSTEM_TRAY_ORIENTATION", xlib.False);
+        self.net_system_tray_visual = xlib.XInternAtom(display, "_NET_SYSTEM_TRAY_VISUAL", xlib.False);
+        self.xembed = xlib.XInternAtom(display, "_XEMBED", xlib.False);
+        self.xembed_info = xlib.XInternAtom(display, "_XEMBED_INFO", xlib.False);
+
+        var selection_name: [32]u8 = undefined;
+        const name_len = std.fmt.bufPrint(&selection_name, "_NET_SYSTEM_TRAY_S{d}", .{screen}) catch return null;
+        selection_name[name_len.len] = 0;
+        self.manager_atom = xlib.XInternAtom(display, @ptrCast(&selection_name), xlib.False);
+
+        const current_owner = xlib.c.XGetSelectionOwner(display, self.manager_atom);
+        if (current_owner != xlib.None) {
+            std.debug.print("systray: another systray is already running\n", .{});
+            allocator.destroy(self);
+            return null;
+        }
+
+        self.window = xlib.c.XCreateSimpleWindow(
+            display,
+            bar_win,
+            0,
+            0,
+            1,
+            @intCast(bar_height),
+            0,
+            0,
+            0,
+        );
+
+        var attrs: xlib.c.XSetWindowAttributes = undefined;
+        attrs.event_mask = xlib.c.SubstructureNotifyMask | xlib.c.SubstructureRedirectMask | xlib.c.StructureNotifyMask | xlib.c.ExposureMask;
+        attrs.override_redirect = xlib.True;
+        attrs.background_pixel = background;
+        _ = xlib.c.XChangeWindowAttributes(
+            display,
+            self.window,
+            xlib.c.CWEventMask | xlib.c.CWOverrideRedirect | xlib.c.CWBackPixel,
+            &attrs,
+        );
+
+        _ = xlib.c.XSetSelectionOwner(display, self.manager_atom, self.window, xlib.CurrentTime);
+        if (xlib.c.XGetSelectionOwner(display, self.manager_atom) != self.window) {
+            std.debug.print("systray: failed to acquire selection ownership\n", .{});
+            _ = xlib.c.XDestroyWindow(display, self.window);
+            allocator.destroy(self);
+            return null;
+        }
+
+        const orientation: c_long = 0;
+        _ = xlib.XChangeProperty(
+            display,
+            self.window,
+            self.net_system_tray_orientation,
+            xlib.XA_CARDINAL,
+            32,
+            xlib.PropModeReplace,
+            @ptrCast(&orientation),
+            1,
+        );
+
+        self.sendManagerMessage(root);
+
+        _ = xlib.XMapWindow(display, self.window);
+        _ = xlib.XSync(display, xlib.False);
+
+        std.debug.print("systray: initialized on screen {d}\n", .{screen});
+        return self;
+    }
+
+    pub fn deinit(self: *Systray) void {
+        for (self.icons.items) |icon| {
+            _ = xlib.c.XUnmapWindow(self.display, icon.window);
+            _ = xlib.c.XReparentWindow(self.display, icon.window, xlib.XRootWindow(self.display, self.screen), 0, 0);
+        }
+        self.icons.deinit(self.allocator);
+        _ = xlib.c.XDestroyWindow(self.display, self.window);
+        self.allocator.destroy(self);
+    }
+
+    fn sendManagerMessage(self: *Systray, root: xlib.Window) void {
+        var ev: xlib.c.XClientMessageEvent = undefined;
+        ev.type = xlib.ClientMessage;
+        ev.window = root;
+        ev.message_type = xlib.XInternAtom(self.display, "MANAGER", xlib.False);
+        ev.format = 32;
+        ev.data.l[0] = xlib.CurrentTime;
+        ev.data.l[1] = @intCast(self.manager_atom);
+        ev.data.l[2] = @intCast(self.window);
+        ev.data.l[3] = 0;
+        ev.data.l[4] = 0;
+
+        _ = xlib.XSendEvent(
+            self.display,
+            root,
+            xlib.False,
+            xlib.c.StructureNotifyMask,
+            @ptrCast(&ev),
+        );
+    }
+
+    fn sendXembedMessage(self: *Systray, win: xlib.Window, msg: c_long, detail: c_long, data1: c_long, data2: c_long) void {
+        var ev: xlib.c.XClientMessageEvent = undefined;
+        ev.type = xlib.ClientMessage;
+        ev.window = win;
+        ev.message_type = self.xembed;
+        ev.format = 32;
+        ev.data.l[0] = xlib.CurrentTime;
+        ev.data.l[1] = msg;
+        ev.data.l[2] = detail;
+        ev.data.l[3] = data1;
+        ev.data.l[4] = data2;
+
+        _ = xlib.XSendEvent(
+            self.display,
+            win,
+            xlib.False,
+            xlib.c.NoEventMask,
+            @ptrCast(&ev),
+        );
+    }
+
+    fn sendConfigureNotify(self: *Systray, win: xlib.Window, x: i32, y: i32, w: i32, h: i32) void {
+        var ev: xlib.c.XConfigureEvent = undefined;
+        ev.type = xlib.ConfigureNotify;
+        ev.event = win;
+        ev.window = win;
+        ev.x = x;
+        ev.y = y;
+        ev.width = w;
+        ev.height = h;
+        ev.border_width = 0;
+        ev.above = xlib.None;
+        ev.override_redirect = xlib.False;
+
+        _ = xlib.XSendEvent(
+            self.display,
+            win,
+            xlib.False,
+            xlib.c.StructureNotifyMask,
+            @ptrCast(&ev),
+        );
+    }
+
+    fn getXembedInfo(self: *Systray, win: xlib.Window) ?struct { version: c_ulong, flags: c_ulong } {
+        var actual_type: xlib.Atom = 0;
+        var actual_format: c_int = 0;
+        var nitems: c_ulong = 0;
+        var bytes_after: c_ulong = 0;
+        var data: [*c]u8 = null;
+
+        const result = xlib.XGetWindowProperty(
+            self.display,
+            win,
+            self.xembed_info,
+            0,
+            2,
+            xlib.False,
+            self.xembed_info,
+            &actual_type,
+            &actual_format,
+            &nitems,
+            &bytes_after,
+            &data,
+        );
+
+        if (result != 0 or actual_type != self.xembed_info or actual_format != 32 or nitems < 2) {
+            if (data != null) _ = xlib.XFree(data);
+            return null;
+        }
+
+        const info_ptr: [*]c_ulong = @ptrCast(@alignCast(data));
+        const version = info_ptr[0];
+        const flags = info_ptr[1];
+        _ = xlib.XFree(data);
+
+        return .{ .version = version, .flags = flags };
+    }
+
+    pub fn handleClientMessage(self: *Systray, ev: *xlib.XClientMessageEvent) bool {
+        if (ev.message_type != self.net_system_tray_opcode) return false;
+
+        const opcode = ev.data.l[1];
+        if (opcode == SYSTEM_TRAY_REQUEST_DOCK) {
+            const icon_win: xlib.Window = @intCast(ev.data.l[2]);
+            self.dockIcon(icon_win);
+            return true;
+        }
+
+        return false;
+    }
+
+    fn updateIconGeometry(self: *Systray, icon: *Icon, w: i32, h: i32) void {
+        _ = w;
+        _ = h;
+        icon.width = self.icon_size;
+        icon.height = self.icon_size;
+
+        _ = xlib.c.XResizeWindow(
+            self.display,
+            icon.window,
+            @intCast(icon.width),
+            @intCast(icon.height),
+        );
+    }
+
+    fn dockIcon(self: *Systray, icon_win: xlib.Window) void {
+        for (self.icons.items) |icon| {
+            if (icon.window == icon_win) return;
+        }
+
+        var wa: xlib.XWindowAttributes = undefined;
+        if (xlib.XGetWindowAttributes(self.display, icon_win, &wa) == 0) {
+            std.debug.print("systray: failed to get window attributes for icon 0x{x}\n", .{icon_win});
+            return;
+        }
+
+        _ = xlib.c.XSetWindowBorderWidth(self.display, icon_win, 0);
+
+        _ = xlib.c.XSelectInput(
+            self.display,
+            icon_win,
+            xlib.c.StructureNotifyMask | xlib.c.PropertyChangeMask | xlib.c.ResizeRedirectMask,
+        );
+
+        _ = xlib.c.XReparentWindow(
+            self.display,
+            icon_win,
+            self.window,
+            0,
+            0,
+        );
+
+        const info = self.getXembedInfo(icon_win);
+        const mapped = if (info) |i| (i.flags & XEMBED_MAPPED) != 0 else true;
+
+        var icon = Icon{
+            .window = icon_win,
+            .width = self.icon_size,
+            .height = self.icon_size,
+            .mapped = mapped,
+        };
+
+        self.updateIconGeometry(&icon, wa.width, wa.height);
+
+        self.icons.append(self.allocator, icon) catch return;
+
+        self.sendXembedMessage(icon_win, XEMBED_EMBEDDED_NOTIFY, 0, @intCast(self.window), XEMBED_VERSION);
+        self.sendXembedMessage(icon_win, XEMBED_WINDOW_ACTIVATE, 0, 0, 0);
+        self.sendXembedMessage(icon_win, XEMBED_FOCUS_IN, 0, 0, 0);
+
+        if (mapped) {
+            _ = xlib.XMapWindow(self.display, icon_win);
+        }
+
+        self.arrangeIcons();
+        std.debug.print("systray: docked icon 0x{x} (size {}x{})\n", .{ icon_win, icon.width, icon.height });
+    }
+
+    pub fn handleConfigureRequest(self: *Systray, ev: *xlib.XConfigureRequestEvent) bool {
+        for (self.icons.items) |*icon| {
+            if (icon.window == ev.window) {
+                if ((ev.value_mask & xlib.c.CWWidth) != 0 or (ev.value_mask & xlib.c.CWHeight) != 0) {
+                    self.updateIconGeometry(icon, ev.width, ev.height);
+                    self.arrangeIcons();
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    pub fn handleResizeRequest(self: *Systray, win: xlib.Window, w: c_int, h: c_int) bool {
+        for (self.icons.items) |*icon| {
+            if (icon.window == win) {
+                self.updateIconGeometry(icon, w, h);
+                self.arrangeIcons();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    pub fn handleDestroyNotify(self: *Systray, win: xlib.Window) bool {
+        return self.removeIcon(win);
+    }
+
+    pub fn handleUnmapNotify(self: *Systray, win: xlib.Window) bool {
+        for (self.icons.items) |*icon| {
+            if (icon.window == win) {
+                icon.mapped = false;
+                self.arrangeIcons();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    pub fn handleMapNotify(self: *Systray, win: xlib.Window) bool {
+        for (self.icons.items) |*icon| {
+            if (icon.window == win) {
+                icon.mapped = true;
+                self.arrangeIcons();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    pub fn handlePropertyNotify(self: *Systray, ev: *xlib.XPropertyEvent) bool {
+        if (ev.atom != self.xembed_info) return false;
+
+        for (self.icons.items) |*icon| {
+            if (icon.window == ev.window) {
+                const info = self.getXembedInfo(icon.window) orelse return true;
+                const should_map = (info.flags & XEMBED_MAPPED) != 0;
+
+                if (should_map and !icon.mapped) {
+                    icon.mapped = true;
+                    _ = xlib.XMapWindow(self.display, icon.window);
+                    self.arrangeIcons();
+                } else if (!should_map and icon.mapped) {
+                    icon.mapped = false;
+                    _ = xlib.c.XUnmapWindow(self.display, icon.window);
+                    self.arrangeIcons();
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    pub fn handleReparentNotify(self: *Systray, win: xlib.Window, parent: xlib.Window) bool {
+        if (parent != self.window) {
+            return self.removeIcon(win);
+        }
+        return false;
+    }
+
+    fn removeIcon(self: *Systray, win: xlib.Window) bool {
+        for (self.icons.items, 0..) |icon, i| {
+            if (icon.window == win) {
+                _ = self.icons.orderedRemove(i);
+                self.arrangeIcons();
+                std.debug.print("systray: removed icon 0x{x}\n", .{win});
+                return true;
+            }
+        }
+        return false;
+    }
+
+    fn arrangeIcons(self: *Systray) void {
+        const spacing: i32 = 4;
+        var x: i32 = 0;
+        const y: i32 = @divTrunc(self.bar_height - self.icon_size, 2);
+
+        for (self.icons.items) |icon| {
+            if (icon.mapped) {
+                _ = xlib.XMoveWindow(self.display, icon.window, x, y);
+                self.sendConfigureNotify(icon.window, x, y, icon.width, icon.height);
+                x += icon.width + spacing;
+            }
+        }
+
+        const total_width: u32 = if (x > 0) @intCast(x) else 1;
+        _ = xlib.c.XResizeWindow(self.display, self.window, total_width, @intCast(self.bar_height));
+        _ = xlib.XSync(self.display, xlib.False);
+    }
+
+    pub fn width(self: *const Systray) i32 {
+        const spacing: i32 = 4;
+        var w: i32 = 0;
+        for (self.icons.items) |icon| {
+            if (icon.mapped) {
+                w += icon.width + spacing;
+            }
+        }
+        return w;
+    }
+
+    pub fn updatePosition(self: *Systray, x: i32, y: i32) void {
+        _ = xlib.XMoveWindow(self.display, self.window, x, y);
+    }
+
+    pub fn isIconWindow(self: *const Systray, win: xlib.Window) bool {
+        if (win == self.window) return true;
+        for (self.icons.items) |icon| {
+            if (icon.window == win) return true;
+        }
+        return false;
+    }
+};

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -66,6 +66,7 @@ pub const BlockType = enum {
     shell,
     battery,
     cpu_temp,
+    systray,
 };
 
 pub const ClickTarget = enum {

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -67,6 +67,7 @@ pub const BlockType = enum {
     shell,
     battery,
     cpu_temp,
+    systray,
 };
 
 pub const ClickTarget = enum {

--- a/src/config/lua.zig
+++ b/src/config/lua.zig
@@ -291,6 +291,9 @@ fn registerBarModule(state: *c.lua_State) void {
     c.lua_pushcfunction(state, luaBarBlockBattery);
     c.lua_setfield(state, -2, "battery");
 
+    c.lua_pushcfunction(state, luaBarBlockSystray);
+    c.lua_setfield(state, -2, "systray");
+
     c.lua_setfield(state, -2, "block");
 
     c.lua_setfield(state, -2, "bar");
@@ -853,6 +856,8 @@ fn parseBlockConfig(state: *c.lua_State, idx: c_int) ?Block {
             c.lua_settop(state, -2);
         }
         c.lua_settop(state, -2);
+    } else if (std.mem.eql(u8, block_type_str, "Systray")) {
+        block.block_type = .systray;
     } else {
         return null;
     }
@@ -925,6 +930,12 @@ fn luaBarBlockStatic(state: ?*c.lua_State) callconv(.c) c_int {
     const text = getLuaString(s, -1);
     c.lua_settop(s, -2);
     createBlockTable(s, "Static", text);
+    return 1;
+}
+
+fn luaBarBlockSystray(state: ?*c.lua_State) callconv(.c) c_int {
+    const s = state orelse return 0;
+    createBlockTable(s, "Systray", null);
     return 1;
 }
 

--- a/src/config/lua.zig
+++ b/src/config/lua.zig
@@ -294,6 +294,9 @@ fn registerBarModule(state: *c.lua_State) void {
     c.lua_pushcfunction(state, luaBarBlockBattery);
     c.lua_setfield(state, -2, "battery");
 
+    c.lua_pushcfunction(state, luaBarBlockSystray);
+    c.lua_setfield(state, -2, "systray");
+
     c.lua_setfield(state, -2, "block");
 
     c.lua_setfield(state, -2, "bar");
@@ -882,6 +885,8 @@ fn parseBlockConfig(state: *c.lua_State, idx: c_int) ?Block {
             c.lua_settop(state, -2);
         }
         c.lua_settop(state, -2);
+    } else if (std.mem.eql(u8, block_type_str, "Systray")) {
+        block.block_type = .systray;
     } else {
         return null;
     }
@@ -954,6 +959,12 @@ fn luaBarBlockStatic(state: ?*c.lua_State) callconv(.c) c_int {
     const text = getLuaString(s, -1);
     c.lua_settop(s, -2);
     createBlockTable(s, "Static", text);
+    return 1;
+}
+
+fn luaBarBlockSystray(state: ?*c.lua_State) callconv(.c) c_int {
+    const s = state orelse return 0;
+    createBlockTable(s, "Systray", null);
     return 1;
 }
 

--- a/src/wm/handlers.zig
+++ b/src/wm/handlers.zig
@@ -30,6 +30,7 @@ pub fn handleEvent(event: *xlib.XEvent, wm: *WindowManager) void {
         .motion_notify => handleMotionNotify(&event.xmotion, wm),
         .client_message => handleClientMessage(&event.xclient, wm),
         .button_press => handleButtonPress(&event.xbutton, wm),
+        .button_release => handleButtonRelease(&event.xbutton, wm),
         .expose => handleExpose(&event.xexpose, wm),
         .property_notify => handlePropertyNotify(&event.xproperty, wm),
         .mapping_notify => handleMappingNotify(&event.xmapping, wm),
@@ -207,6 +208,10 @@ fn handleExpose(event: *xlib.XExposeEvent, wm: *WindowManager) void {
 
 fn handleButtonPress(event: *xlib.XButtonEvent, wm: *WindowManager) void {
     std.debug.print("button_press: window=0x{x} subwindow=0x{x}\n", .{ event.window, event.subwindow });
+
+    if (wm.getSystray()) |tray| {
+        if (tray.handleButtonPress(event)) return;
+    }
 
     const clicked_monitor = monitor_mod.windowToMonitor(wm, event.window);
     if (clicked_monitor) |monitor| {
@@ -434,5 +439,11 @@ fn handleResizeRequest(event: *xlib.XResizeRequestEvent, wm: *WindowManager) voi
         if (tray.handleResizeRequest(event.window, event.width, event.height)) {
             wm.invalidateBars();
         }
+    }
+}
+
+fn handleButtonRelease(event: *xlib.XButtonEvent, wm: *WindowManager) void {
+    if (wm.getSystray()) |tray| {
+        _ = tray.handleButtonRelease(event);
     }
 }

--- a/src/wm/handlers.zig
+++ b/src/wm/handlers.zig
@@ -31,6 +31,7 @@ pub fn handleEvent(event: *xlib.XEvent, wm: *WindowManager) void {
         .motion_notify => handleMotionNotify(&event.xmotion, wm),
         .client_message => handleClientMessage(&event.xclient, wm),
         .button_press => handleButtonPress(&event.xbutton, wm),
+        .button_release => handleButtonRelease(&event.xbutton, wm),
         .expose => handleExpose(&event.xexpose, wm),
         .property_notify => handlePropertyNotify(&event.xproperty, wm),
         .mapping_notify => handleMappingNotify(&event.xmapping, wm),
@@ -229,6 +230,10 @@ fn handleConfigureNotify(event: *xlib.XConfigureEvent, wm: *WindowManager) void 
 
 fn handleButtonPress(event: *xlib.XButtonEvent, wm: *WindowManager) void {
     std.debug.print("button_press: window=0x{x} subwindow=0x{x}\n", .{ event.window, event.subwindow });
+
+    if (wm.getSystray()) |tray| {
+        if (tray.handleButtonPress(event)) return;
+    }
 
     const clicked_monitor = monitor_mod.windowToMonitor(wm, event.window);
     if (clicked_monitor) |monitor| {
@@ -460,5 +465,11 @@ fn handleResizeRequest(event: *xlib.XResizeRequestEvent, wm: *WindowManager) voi
         if (tray.handleResizeRequest(event.window, event.width, event.height)) {
             wm.invalidateBars();
         }
+    }
+}
+
+fn handleButtonRelease(event: *xlib.XButtonEvent, wm: *WindowManager) void {
+    if (wm.getSystray()) |tray| {
+        _ = tray.handleButtonRelease(event);
     }
 }

--- a/src/wm/handlers.zig
+++ b/src/wm/handlers.zig
@@ -33,12 +33,19 @@ pub fn handleEvent(event: *xlib.XEvent, wm: *WindowManager) void {
         .expose => handleExpose(&event.xexpose, wm),
         .property_notify => handlePropertyNotify(&event.xproperty, wm),
         .mapping_notify => handleMappingNotify(&event.xmapping, wm),
+        .reparent_notify => handleReparentNotify(&event.xreparent, wm),
+        .map_notify => handleMapNotify(&event.xmap, wm),
+        .resize_request => handleResizeRequest(&event.xresizerequest, wm),
         else => {},
     }
 }
 
 fn handleMapRequest(event: *xlib.XMapRequestEvent, wm: *WindowManager) void {
     std.debug.print("map_request: window=0x{x}\n", .{event.window});
+
+    if (wm.getSystray()) |tray| {
+        if (tray.isIconWindow(event.window)) return;
+    }
 
     var window_attributes: xlib.XWindowAttributes = undefined;
     if (xlib.XGetWindowAttributes(wm.display.handle, event.window, &window_attributes) == 0) {
@@ -55,6 +62,13 @@ fn handleMapRequest(event: *xlib.XMapRequestEvent, wm: *WindowManager) void {
 }
 
 fn handleConfigureRequest(event: *xlib.XConfigureRequestEvent, wm: *WindowManager) void {
+    if (wm.getSystray()) |tray| {
+        if (tray.handleConfigureRequest(event)) {
+            wm.invalidateBars();
+            return;
+        }
+    }
+
     const client = client_mod.windowToClient(wm.monitors, event.window);
 
     if (client) |managed_client| {
@@ -246,6 +260,13 @@ fn handleButtonPress(event: *xlib.XButtonEvent, wm: *WindowManager) void {
 }
 
 fn handleClientMessage(event: *xlib.XClientMessageEvent, wm: *WindowManager) void {
+    if (wm.getSystray()) |tray| {
+        if (tray.handleClientMessage(event)) {
+            wm.invalidateBars();
+            return;
+        }
+    }
+
     const client = client_mod.windowToClient(wm.monitors, event.window) orelse return;
 
     if (event.message_type == wm.atoms.net_wm_state) {
@@ -275,12 +296,26 @@ fn handleClientMessage(event: *xlib.XClientMessageEvent, wm: *WindowManager) voi
 }
 
 fn handleDestroyNotify(event: *xlib.XDestroyWindowEvent, wm: *WindowManager) void {
+    if (wm.getSystray()) |tray| {
+        if (tray.handleDestroyNotify(event.window)) {
+            wm.invalidateBars();
+            return;
+        }
+    }
+
     const client = client_mod.windowToClient(wm.monitors, event.window) orelse return;
     std.debug.print("destroy_notify: window=0x{x}\n", .{event.window});
     core.unmanage(client, wm);
 }
 
 fn handleUnmapNotify(event: *xlib.XUnmapEvent, wm: *WindowManager) void {
+    if (wm.getSystray()) |tray| {
+        if (tray.handleUnmapNotify(event.window)) {
+            wm.invalidateBars();
+            return;
+        }
+    }
+
     const client = client_mod.windowToClient(wm.monitors, event.window) orelse return;
     std.debug.print("unmap_notify: window=0x{x}\n", .{event.window});
     core.unmanage(client, wm);
@@ -338,6 +373,13 @@ fn handlePropertyNotify(event: *xlib.XPropertyEvent, wm: *WindowManager) void {
         return;
     }
 
+    if (wm.getSystray()) |tray| {
+        if (tray.handlePropertyNotify(event)) {
+            wm.invalidateBars();
+            return;
+        }
+    }
+
     const client = client_mod.windowToClient(wm.monitors, event.window) orelse return;
 
     if (event.atom == xlib.XA_WM_TRANSIENT_FOR) {
@@ -364,9 +406,33 @@ fn handlePropertyNotify(event: *xlib.XPropertyEvent, wm: *WindowManager) void {
 
 fn handleMappingNotify(event: *xlib.XMappingEvent, wm: *WindowManager) void {
     _ = xlib.XRefreshKeyboardMapping(event);
-    
+
     if (event.request == xlib.MappingKeyboard or event.request == xlib.MappingModifier) {
         wm.ungrabKeybinds();
         wm.grabKeybinds();
+    }
+}
+
+fn handleReparentNotify(event: *xlib.XReparentEvent, wm: *WindowManager) void {
+    if (wm.getSystray()) |tray| {
+        if (tray.handleReparentNotify(event.window, event.parent)) {
+            wm.invalidateBars();
+        }
+    }
+}
+
+fn handleMapNotify(event: *xlib.c.XMapEvent, wm: *WindowManager) void {
+    if (wm.getSystray()) |tray| {
+        if (tray.handleMapNotify(event.window)) {
+            wm.invalidateBars();
+        }
+    }
+}
+
+fn handleResizeRequest(event: *xlib.XResizeRequestEvent, wm: *WindowManager) void {
+    if (wm.getSystray()) |tray| {
+        if (tray.handleResizeRequest(event.window, event.width, event.height)) {
+            wm.invalidateBars();
+        }
     }
 }

--- a/src/wm/handlers.zig
+++ b/src/wm/handlers.zig
@@ -34,12 +34,19 @@ pub fn handleEvent(event: *xlib.XEvent, wm: *WindowManager) void {
         .expose => handleExpose(&event.xexpose, wm),
         .property_notify => handlePropertyNotify(&event.xproperty, wm),
         .mapping_notify => handleMappingNotify(&event.xmapping, wm),
+        .reparent_notify => handleReparentNotify(&event.xreparent, wm),
+        .map_notify => handleMapNotify(&event.xmap, wm),
+        .resize_request => handleResizeRequest(&event.xresizerequest, wm),
         else => {},
     }
 }
 
 fn handleMapRequest(event: *xlib.XMapRequestEvent, wm: *WindowManager) void {
     std.debug.print("map_request: window=0x{x}\n", .{event.window});
+
+    if (wm.getSystray()) |tray| {
+        if (tray.isIconWindow(event.window)) return;
+    }
 
     var window_attributes: xlib.XWindowAttributes = undefined;
     if (xlib.XGetWindowAttributes(wm.display.handle, event.window, &window_attributes) == 0) {
@@ -56,6 +63,13 @@ fn handleMapRequest(event: *xlib.XMapRequestEvent, wm: *WindowManager) void {
 }
 
 fn handleConfigureRequest(event: *xlib.XConfigureRequestEvent, wm: *WindowManager) void {
+    if (wm.getSystray()) |tray| {
+        if (tray.handleConfigureRequest(event)) {
+            wm.invalidateBars();
+            return;
+        }
+    }
+
     const client = client_mod.windowToClient(wm.monitors, event.window);
 
     if (client) |managed_client| {
@@ -272,6 +286,13 @@ fn handleButtonPress(event: *xlib.XButtonEvent, wm: *WindowManager) void {
 }
 
 fn handleClientMessage(event: *xlib.XClientMessageEvent, wm: *WindowManager) void {
+    if (wm.getSystray()) |tray| {
+        if (tray.handleClientMessage(event)) {
+            wm.invalidateBars();
+            return;
+        }
+    }
+
     const client = client_mod.windowToClient(wm.monitors, event.window) orelse return;
 
     if (event.message_type == wm.atoms.net_wm_state) {
@@ -301,12 +322,26 @@ fn handleClientMessage(event: *xlib.XClientMessageEvent, wm: *WindowManager) voi
 }
 
 fn handleDestroyNotify(event: *xlib.XDestroyWindowEvent, wm: *WindowManager) void {
+    if (wm.getSystray()) |tray| {
+        if (tray.handleDestroyNotify(event.window)) {
+            wm.invalidateBars();
+            return;
+        }
+    }
+
     const client = client_mod.windowToClient(wm.monitors, event.window) orelse return;
     std.debug.print("destroy_notify: window=0x{x}\n", .{event.window});
     core.unmanage(client, wm);
 }
 
 fn handleUnmapNotify(event: *xlib.XUnmapEvent, wm: *WindowManager) void {
+    if (wm.getSystray()) |tray| {
+        if (tray.handleUnmapNotify(event.window)) {
+            wm.invalidateBars();
+            return;
+        }
+    }
+
     const client = client_mod.windowToClient(wm.monitors, event.window) orelse return;
     std.debug.print("unmap_notify: window=0x{x}\n", .{event.window});
     core.unmanage(client, wm);
@@ -364,6 +399,13 @@ fn handlePropertyNotify(event: *xlib.XPropertyEvent, wm: *WindowManager) void {
         return;
     }
 
+    if (wm.getSystray()) |tray| {
+        if (tray.handlePropertyNotify(event)) {
+            wm.invalidateBars();
+            return;
+        }
+    }
+
     const client = client_mod.windowToClient(wm.monitors, event.window) orelse return;
 
     if (event.atom == xlib.XA_WM_TRANSIENT_FOR) {
@@ -390,9 +432,33 @@ fn handlePropertyNotify(event: *xlib.XPropertyEvent, wm: *WindowManager) void {
 
 fn handleMappingNotify(event: *xlib.XMappingEvent, wm: *WindowManager) void {
     _ = xlib.XRefreshKeyboardMapping(event);
-    
+
     if (event.request == xlib.MappingKeyboard or event.request == xlib.MappingModifier) {
         wm.ungrabKeybinds();
         wm.grabKeybinds();
+    }
+}
+
+fn handleReparentNotify(event: *xlib.XReparentEvent, wm: *WindowManager) void {
+    if (wm.getSystray()) |tray| {
+        if (tray.handleReparentNotify(event.window, event.parent)) {
+            wm.invalidateBars();
+        }
+    }
+}
+
+fn handleMapNotify(event: *xlib.c.XMapEvent, wm: *WindowManager) void {
+    if (wm.getSystray()) |tray| {
+        if (tray.handleMapNotify(event.window)) {
+            wm.invalidateBars();
+        }
+    }
+}
+
+fn handleResizeRequest(event: *xlib.XResizeRequestEvent, wm: *WindowManager) void {
+    if (wm.getSystray()) |tray| {
+        if (tray.handleResizeRequest(event.window, event.width, event.height)) {
+            wm.invalidateBars();
+        }
     }
 }

--- a/src/wm/wm.zig
+++ b/src/wm/wm.zig
@@ -301,7 +301,11 @@ pub const WindowManager = struct {
     pub fn populateBarBlocks(self: *WindowManager, bar: *Bar) void {
         if (self.config.blocks.items.len > 0) {
             for (self.config.blocks.items) |cfg_block| {
-                bar.addBlock(configBlockToBarBlock(cfg_block));
+                if (cfg_block.block_type == .systray) {
+                    bar.setSystrayConfig(cfg_block.underline, cfg_block.color);
+                } else {
+                    bar.addBlock(configBlockToBarBlock(cfg_block));
+                }
             }
         } else {
             bar.addBlock(blocks_mod.Block.initRam("", 5, 0x7aa2f7, true));
@@ -597,5 +601,6 @@ pub fn configBlockToBarBlock(cfg: config_mod.Block) blocks_mod.Block {
             cfg.color,
             cfg.underline,
         ),
+        .systray => blocks_mod.Block.initStatic("", 0, false),
     };
 }

--- a/src/wm/wm.zig
+++ b/src/wm/wm.zig
@@ -420,6 +420,7 @@ pub const WindowManager = struct {
         var current_monitor = self.monitors;
         var last_bar: ?*Bar = null;
         var is_first_bar = true;
+        const want_systray = configHasSystray(self.config);
 
         while (current_monitor) |monitor| {
             const bar = Bar.create(
@@ -428,7 +429,7 @@ pub const WindowManager = struct {
                 self.display.screen,
                 monitor,
                 self.config,
-                is_first_bar,
+                is_first_bar and want_systray,
             ) orelse {
                 current_monitor = monitor.next;
                 continue;
@@ -720,6 +721,13 @@ pub const WindowManager = struct {
         }
     }
 };
+
+fn configHasSystray(config: Config) bool {
+    for (config.blocks.items) |block| {
+        if (block.block_type == .systray) return true;
+    }
+    return false;
+}
 
 /// Converts a config block description into a live status bar block.
 pub fn configBlockToBarBlock(cfg: config_mod.Block) blocks_mod.Block {

--- a/src/wm/wm.zig
+++ b/src/wm/wm.zig
@@ -456,7 +456,11 @@ pub const WindowManager = struct {
     pub fn populateBarBlocks(self: *WindowManager, bar: *Bar) void {
         if (self.config.blocks.items.len > 0) {
             for (self.config.blocks.items) |cfg_block| {
-                bar.addBlock(configBlockToBarBlock(cfg_block));
+                if (cfg_block.block_type == .systray) {
+                    bar.setSystrayConfig(cfg_block.underline, cfg_block.color);
+                } else {
+                    bar.addBlock(configBlockToBarBlock(cfg_block));
+                }
             }
         } else {
             bar.addBlock(blocks_mod.Block.initRam("", 5, 0x7aa2f7, true));
@@ -752,6 +756,7 @@ pub fn configBlockToBarBlock(cfg: config_mod.Block) blocks_mod.Block {
             cfg.color,
             cfg.underline,
         ),
+        .systray => blocks_mod.Block.initStatic("", 0, false),
     };
     block.click = cfg.click;
     return block;

--- a/src/wm/wm.zig
+++ b/src/wm/wm.zig
@@ -264,6 +264,7 @@ pub const WindowManager = struct {
     pub fn setupBars(self: *WindowManager) void {
         var current_monitor = self.monitors;
         var last_bar: ?*Bar = null;
+        var is_first_bar = true;
 
         while (current_monitor) |monitor| {
             const bar = Bar.create(
@@ -272,10 +273,12 @@ pub const WindowManager = struct {
                 self.display.screen,
                 monitor,
                 self.config,
+                is_first_bar,
             ) orelse {
                 current_monitor = monitor.next;
                 continue;
             };
+            is_first_bar = false;
 
             if (tiling.bar_height == 0) {
                 tiling.setBarHeight(bar.height);
@@ -325,6 +328,10 @@ pub const WindowManager = struct {
 
     pub fn windowToBar(self: *WindowManager, win: xlib.Window) ?*Bar {
         return bar_mod.windowToBar(self.bars, win);
+    }
+
+    pub fn getSystray(self: *WindowManager) ?*bar_mod.Systray {
+        return bar_mod.getSystray(self.bars);
     }
 
     /// Refreshes the cached numlock modifier bitmask from the X server's

--- a/src/wm/wm.zig
+++ b/src/wm/wm.zig
@@ -419,6 +419,7 @@ pub const WindowManager = struct {
     pub fn setupBars(self: *WindowManager) void {
         var current_monitor = self.monitors;
         var last_bar: ?*Bar = null;
+        var is_first_bar = true;
 
         while (current_monitor) |monitor| {
             const bar = Bar.create(
@@ -427,10 +428,12 @@ pub const WindowManager = struct {
                 self.display.screen,
                 monitor,
                 self.config,
+                is_first_bar,
             ) orelse {
                 current_monitor = monitor.next;
                 continue;
             };
+            is_first_bar = false;
 
             if (tiling.bar_height == 0) {
                 tiling.setBarHeight(bar.height);
@@ -480,6 +483,10 @@ pub const WindowManager = struct {
 
     pub fn windowToBar(self: *WindowManager, win: xlib.Window) ?*Bar {
         return bar_mod.windowToBar(self.bars, win);
+    }
+
+    pub fn getSystray(self: *WindowManager) ?*bar_mod.Systray {
+        return bar_mod.getSystray(self.bars);
     }
 
     /// Refreshes the cached numlock modifier bitmask from the X server's

--- a/src/x11/xlib.zig
+++ b/src/x11/xlib.zig
@@ -282,5 +282,4 @@ pub const XSetSelectionOwner = c.XSetSelectionOwner;
 pub const XGetSelectionOwner = c.XGetSelectionOwner;
 pub const XA_CARDINAL = c.XA_CARDINAL;
 pub const XReparentEvent = c.XReparentEvent;
-pub const XConfigureEvent = c.XConfigureEvent;
 pub const XResizeRequestEvent = c.XResizeRequestEvent;

--- a/src/x11/xlib.zig
+++ b/src/x11/xlib.zig
@@ -275,3 +275,12 @@ pub const XMappingEvent = c.XMappingEvent;
 pub const XRefreshKeyboardMapping = c.XRefreshKeyboardMapping;
 pub const MappingKeyboard = c.MappingKeyboard;
 pub const MappingModifier = c.MappingModifier;
+
+pub const XReparentWindow = c.XReparentWindow;
+pub const XResizeWindow = c.XResizeWindow;
+pub const XSetSelectionOwner = c.XSetSelectionOwner;
+pub const XGetSelectionOwner = c.XGetSelectionOwner;
+pub const XA_CARDINAL = c.XA_CARDINAL;
+pub const XReparentEvent = c.XReparentEvent;
+pub const XConfigureEvent = c.XConfigureEvent;
+pub const XResizeRequestEvent = c.XResizeRequestEvent;

--- a/src/x11/xlib.zig
+++ b/src/x11/xlib.zig
@@ -273,3 +273,12 @@ pub const XMappingEvent = c.XMappingEvent;
 pub const XRefreshKeyboardMapping = c.XRefreshKeyboardMapping;
 pub const MappingKeyboard = c.MappingKeyboard;
 pub const MappingModifier = c.MappingModifier;
+
+pub const XReparentWindow = c.XReparentWindow;
+pub const XResizeWindow = c.XResizeWindow;
+pub const XSetSelectionOwner = c.XSetSelectionOwner;
+pub const XGetSelectionOwner = c.XGetSelectionOwner;
+pub const XA_CARDINAL = c.XA_CARDINAL;
+pub const XReparentEvent = c.XReparentEvent;
+pub const XConfigureEvent = c.XConfigureEvent;
+pub const XResizeRequestEvent = c.XResizeRequestEvent;

--- a/templates/oxwm.lua
+++ b/templates/oxwm.lua
@@ -324,6 +324,11 @@ function oxwm.bar.block.static(config) end
 ---@return table Block configuration
 function oxwm.bar.block.battery(config) end
 
+---Create a system tray block. Including this block enables the tray on the first bar; omitting it disables the tray entirely.
+---@param config {color: string|integer, underline: boolean}? Optional appearance config (only color and underline are used)
+---@return table Block configuration
+function oxwm.bar.block.systray(config) end
+
 ---Set normal tag color scheme (unselected, no windows)
 ---@param foreground string|integer Foreground color
 ---@param background string|integer Background color


### PR DESCRIPTION
<img width="307" height="40" alt="image" src="https://github.com/user-attachments/assets/686d9e3d-5c71-4e2b-848a-e952c42c34ec" />

add this block in config.lua to enable the systray

```lua
    oxwm.bar.block.systray({
        color = "#7aa2f7",
        underline = false,
    }),
```
supports right click and left click on systray icons for more options 