### PR TITLE
Use Zig 0.15.2 for Nix Build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   callPackage,
-  zig,
+  zig_0_15,
   pkg-config,
   libx11,
   libxft,
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   deps = callPackage ./build.zig.zon.nix {};
 
-  nativeBuildInputs = [zig.hook pkg-config];
+  nativeBuildInputs = [zig_0_15.hook pkg-config];
 
   buildInputs = [
     libx11


### PR DESCRIPTION
Nixpkgs updated their zig version to 0.16.0. This means that the build of oxwm from the flake in this repository now fails. This commit simply pins the version of Zig in `default.nix` to Zig 0.15.2 so it will compile