### PR TITLE
Zig Version 0.16.0 Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 zig-out/
 .zig-cache/
 .direnv/
+zig-pkg/
 
 # Nix
 result

--- a/build.zig
+++ b/build.zig
@@ -13,6 +13,7 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("src/main.zig"),
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
         }),
     });
 
@@ -27,12 +28,12 @@ pub fn build(b: *std.Build) void {
     exe.use_lld = false;
 
     const lua = buildLua(b, lua_dep, target, optimize);
-    exe.linkLibrary(lua);
-    exe.linkSystemLibrary("X11");
-    exe.linkSystemLibrary("Xinerama");
-    exe.linkSystemLibrary("Xft");
-    exe.linkSystemLibrary("fontconfig");
-    exe.linkLibC();
+
+    exe.root_module.linkLibrary(lua);
+    exe.root_module.linkSystemLibrary("X11", .{});
+    exe.root_module.linkSystemLibrary("Xinerama", .{});
+    exe.root_module.linkSystemLibrary("Xft", .{});
+    exe.root_module.linkSystemLibrary("fontconfig", .{});
 
     b.installArtifact(exe);
 
@@ -60,16 +61,16 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("src/main.zig"),
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
         }),
     });
     src_main_unit_tests.use_lld = false;
     src_main_unit_tests.root_module.addIncludePath(lua_headers);
-    src_main_unit_tests.linkLibrary(lua);
-    src_main_unit_tests.linkSystemLibrary("X11");
-    src_main_unit_tests.linkSystemLibrary("Xinerama");
-    src_main_unit_tests.linkSystemLibrary("Xft");
-    src_main_unit_tests.linkSystemLibrary("fontconfig");
-    src_main_unit_tests.linkLibC();
+    src_main_unit_tests.root_module.linkLibrary(lua);
+    src_main_unit_tests.root_module.linkSystemLibrary("X11", .{});
+    src_main_unit_tests.root_module.linkSystemLibrary("Xinerama", .{});
+    src_main_unit_tests.root_module.linkSystemLibrary("Xft", .{});
+    src_main_unit_tests.root_module.linkSystemLibrary("fontconfig", .{});
     test_step.dependOn(&b.addRunArtifact(src_main_unit_tests).step);
 
     const lua_config_tests = b.addTest(.{
@@ -77,6 +78,7 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("tests/lua_config_tests.zig"),
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
         }),
     });
     lua_config_tests.use_lld = false;
@@ -88,8 +90,7 @@ pub fn build(b: *std.Build) void {
     });
     lua_config_module.addIncludePath(lua_headers);
     lua_config_tests.root_module.addImport("lua", lua_config_module);
-    lua_config_tests.linkLibrary(lua);
-    lua_config_tests.linkLibC();
+    lua_config_tests.root_module.linkLibrary(lua);
     test_step.dependOn(&b.addRunArtifact(lua_config_tests).step);
 
     const xephyr_step = b.step("xephyr", "Run in Xephyr (1280x800 on :2)");
@@ -172,11 +173,11 @@ fn buildLua(b: *std.Build, lua_dep: *std.Build.Dependency, target: std.Build.Res
         .root_module = b.createModule(.{
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
         }),
     });
-    lua.linkLibC();
-    lua.addIncludePath(lua_src.path("src/"));
-    lua.addCSourceFiles(.{
+    lua.root_module.addIncludePath(lua_src.path("src/"));
+    lua.root_module.addCSourceFiles(.{
         .root = lua_src.path("src/"),
         .files = &.{
             "lapi.c",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,8 +1,8 @@
 .{
     .name = .oxwm,
-    .version = "0.11.4",
+    .version = "0.12.0",
     .fingerprint = 0x4b9ef3753914924d, // Changing this has security and trust implications.
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .lua = .{
             .url = "https://www.lua.org/ftp/lua-5.4.8.tar.gz",

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771008912,
-        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
         "type": "github"
       },
       "original": {

--- a/src/animations.zig
+++ b/src/animations.zig
@@ -30,23 +30,23 @@ pub const ScrollAnimation = struct {
     easing: Easing = .ease_out,
     active: bool = false,
 
-    pub fn start(self: *ScrollAnimation, from: i32, to: i32, config: AnimationConfig) void {
+    pub fn start(self: *ScrollAnimation, io: std.Io, from: i32, to: i32, config: AnimationConfig) void {
         if (from == to) {
             self.active = false;
             return;
         }
         self.start_value = from;
         self.end_value = to;
-        self.start_time = std.time.milliTimestamp();
+        self.start_time = std.Io.Timestamp.now(io, .awake).toMilliseconds();
         self.duration_ms = config.duration_ms;
         self.easing = config.easing;
         self.active = true;
     }
 
-    pub fn update(self: *ScrollAnimation) ?i32 {
+    pub fn update(self: *ScrollAnimation, io: std.Io) ?i32 {
         if (!self.active) return null;
 
-        const now = std.time.milliTimestamp();
+        const now = std.Io.Timestamp.now(io, .awake).toMilliseconds();
         const elapsed = now - self.start_time;
 
         if (elapsed >= @as(i64, @intCast(self.duration_ms))) {

--- a/src/bar/bar.zig
+++ b/src/bar/bar.zig
@@ -11,7 +11,7 @@ const Block = blocks_mod.Block;
 pub const Systray = systray_mod.Systray;
 
 fn getLayoutSymbol(layout_index: u32, config: config_mod.Config) []const u8 {
-    const layout = std.meta.intToEnum(config_mod.Layouts, layout_index) catch return "[?]";
+    const layout = std.enums.fromInt(config_mod.Layouts, layout_index) orelse return "[?]";
     return switch (layout) {
         .tiling => config.layout_tile_symbol,
         .monocle => config.layout_monocle_symbol,
@@ -303,10 +303,10 @@ pub const Bar = struct {
     }
 
     /// Updates all blocks and marks the bar dirty if any block changed.
-    pub fn updateBlocks(self: *Bar) void {
+    pub fn updateBlocks(self: *Bar, io: std.Io, gpa: std.mem.Allocator) void {
         var changed = false;
         for (self.blocks.items) |*block| {
-            if (block.update()) changed = true;
+            if (block.update(io, gpa)) changed = true;
         }
         if (changed) self.needs_redraw = true;
     }

--- a/src/bar/blocks/battery.zig
+++ b/src/bar/blocks/battery.zig
@@ -27,11 +27,11 @@ pub const Battery = struct {
         };
     }
 
-    pub fn content(self: *Battery, buffer: []u8) []const u8 {
+    pub fn content(self: *Battery, io: std.Io, buffer: []u8) []const u8 {
         var path_buf: [128]u8 = undefined;
 
-        const capacity = self.readBatteryFile(&path_buf, "capacity") orelse return buffer[0..0];
-        const status = self.readBatteryStatus(&path_buf) orelse return buffer[0..0];
+        const capacity = self.readBatteryFile(io, &path_buf, "capacity") orelse return buffer[0..0];
+        const status = self.readBatteryStatus(io, &path_buf) orelse return buffer[0..0];
 
         const format = switch (status) {
             .charging => self.format_charging,
@@ -47,14 +47,14 @@ pub const Battery = struct {
 
     const Status = enum { charging, discharging, full };
 
-    fn readBatteryStatus(self: *Battery, path_buf: *[128]u8) ?Status {
+    fn readBatteryStatus(self: *Battery, io: std.Io, path_buf: *[128]u8) ?Status {
         const path = std.fmt.bufPrint(path_buf, "/sys/class/power_supply/{s}/status", .{self.battery_name}) catch return null;
 
-        const file = std.fs.openFileAbsolute(path, .{}) catch return null;
-        defer file.close();
+        const file = std.Io.Dir.openFileAbsolute(io, path, .{}) catch return null;
+        defer file.close(io);
 
         var buf: [32]u8 = undefined;
-        const len = file.read(&buf) catch return null;
+        const len = file.readStreaming(io, &.{&buf}) catch return null;
         const status_str = std.mem.trim(u8, buf[0..len], " \n\r\t");
 
         if (std.mem.eql(u8, status_str, "Charging")) return .charging;
@@ -64,14 +64,14 @@ pub const Battery = struct {
         return .discharging;
     }
 
-    fn readBatteryFile(self: *Battery, path_buf: *[128]u8, file_name: []const u8) ?u8 {
+    fn readBatteryFile(self: *Battery, io: std.Io, path_buf: *[128]u8, file_name: []const u8) ?u8 {
         const path = std.fmt.bufPrint(path_buf, "/sys/class/power_supply/{s}/{s}", .{ self.battery_name, file_name }) catch return null;
 
-        const file = std.fs.openFileAbsolute(path, .{}) catch return null;
-        defer file.close();
+        const file = std.Io.Dir.openFileAbsolute(io, path, .{}) catch return null;
+        defer file.close(io);
 
         var buf: [16]u8 = undefined;
-        const len = file.read(&buf) catch return null;
+        const len = file.readStreaming(io, &.{&buf}) catch return null;
         const value_str = std.mem.trim(u8, buf[0..len], " \n\r\t");
 
         return std.fmt.parseInt(u8, value_str, 10) catch null;

--- a/src/bar/blocks/blocks.zig
+++ b/src/bar/blocks/blocks.zig
@@ -104,11 +104,11 @@ pub const Block = struct {
         };
     }
 
-    pub fn update(self: *Block) bool {
+    pub fn update(self: *Block, io: std.Io, gpa: std.mem.Allocator) bool {
         const interval_secs = self.interval();
         if (interval_secs == 0) return false;
 
-        const now = std.time.timestamp();
+        const now = std.Io.Timestamp.now(io, .real).toSeconds();
         if (now - self.last_update < @as(i64, @intCast(interval_secs))) {
             return false;
         }
@@ -118,10 +118,10 @@ pub const Block = struct {
         const result = switch (self.data) {
             .static => |*s| s.content(&self.cached_content),
             .datetime => |*d| d.content(&self.cached_content),
-            .ram => |*r| r.content(&self.cached_content),
-            .shell => |*s| s.content(&self.cached_content),
-            .battery => |*b| b.content(&self.cached_content),
-            .cpu_temp => |*c| c.content(&self.cached_content),
+            .ram => |*r| r.content(io, &self.cached_content),
+            .shell => |*s| s.content(io, gpa, &self.cached_content),
+            .battery => |*b| b.content(io, &self.cached_content),
+            .cpu_temp => |*c| c.content(io, &self.cached_content),
         };
 
         self.cached_len = result.len;

--- a/src/bar/blocks/blocks.zig
+++ b/src/bar/blocks/blocks.zig
@@ -108,7 +108,8 @@ pub const Block = struct {
         const interval_secs = self.interval();
         if (interval_secs == 0) return false;
 
-        const now = std.Io.Timestamp.now(io, .real).toSeconds();
+        // .awake (monotonic) for interval bookkeeping, not .real (wall-clock) — std.Io rework gives us a clock enum now, and a wall-clock backstep would stretch intervals.
+        const now = std.Io.Timestamp.now(io, .awake).toSeconds();
         if (now - self.last_update < @as(i64, @intCast(interval_secs))) {
             return false;
         }

--- a/src/bar/blocks/cpu_temp.zig
+++ b/src/bar/blocks/cpu_temp.zig
@@ -15,7 +15,7 @@ pub const CpuTemp = struct {
         interval_secs: u64,
         color: c_ulong,
     ) CpuTemp {
-        var self = CpuTemp{
+        return .{
             .format = format,
             .device = device,
             .interval_secs = interval_secs,
@@ -23,11 +23,9 @@ pub const CpuTemp = struct {
             .cached_path = undefined,
             .cached_path_len = 0,
         };
-        self.detectPath();
-        return self;
     }
 
-    fn detectPath(self: *CpuTemp) void {
+    fn detectPath(self: *CpuTemp, io: std.Io) void {
         if (self.device.len > 0 and self.device[0] == '/') {
             if (self.device.len <= self.cached_path.len) {
                 @memcpy(self.cached_path[0..self.device.len], self.device);
@@ -37,45 +35,45 @@ pub const CpuTemp = struct {
         }
 
         if (self.device.len > 0) {
-            if (self.tryPath("/sys/class/thermal/{s}/temp", self.device)) return;
-            if (self.tryPath("/sys/class/hwmon/{s}/temp1_input", self.device)) return;
+            if (self.tryPath(io, "/sys/class/thermal/{s}/temp", self.device)) return;
+            if (self.tryPath(io, "/sys/class/hwmon/{s}/temp1_input", self.device)) return;
         }
 
-        if (self.findHwmonCpu()) return;
+        if (self.findHwmonCpu(io)) return;
 
-        if (self.tryPath("/sys/class/thermal/{s}/temp", "thermal_zone0")) return;
+        if (self.tryPath(io, "/sys/class/thermal/{s}/temp", "thermal_zone0")) return;
     }
 
-    fn tryPath(self: *CpuTemp, comptime fmt: []const u8, device: []const u8) bool {
+    fn tryPath(self: *CpuTemp, io: std.Io, comptime fmt: []const u8, device: []const u8) bool {
         const path = std.fmt.bufPrint(&self.cached_path, fmt, .{device}) catch return false;
-        const file = std.fs.openFileAbsolute(path, .{}) catch return false;
-        file.close();
+        const file = std.Io.Dir.openFileAbsolute(io, path, .{}) catch return false;
+        file.close(io);
         self.cached_path_len = path.len;
         return true;
     }
 
-    fn findHwmonCpu(self: *CpuTemp) bool {
-        var dir = std.fs.openDirAbsolute("/sys/class/hwmon", .{ .iterate = true }) catch return false;
-        defer dir.close();
+    fn findHwmonCpu(self: *CpuTemp, io: std.Io) bool {
+        var dir = std.Io.Dir.openDirAbsolute(io, "/sys/class/hwmon", .{ .iterate = true }) catch return false;
+        defer dir.close(io);
 
         var iter = dir.iterate();
-        while (iter.next() catch null) |entry| {
+        while (iter.next(io) catch null) |entry| {
             if (entry.kind != .directory and entry.kind != .sym_link) continue;
 
             var name_path: [128]u8 = undefined;
             const name_path_str = std.fmt.bufPrint(&name_path, "/sys/class/hwmon/{s}/name", .{entry.name}) catch continue;
 
-            const name_file = std.fs.openFileAbsolute(name_path_str, .{}) catch continue;
-            defer name_file.close();
+            const name_file = std.Io.Dir.openFileAbsolute(io, name_path_str, .{}) catch continue;
+            defer name_file.close(io);
 
             var name_buf: [32]u8 = undefined;
-            const name_len = name_file.read(&name_buf) catch continue;
+            const name_len = name_file.readStreaming(io, &.{&name_buf}) catch continue;
             const name = std.mem.trim(u8, name_buf[0..name_len], " \n\r\t");
 
             if (std.mem.eql(u8, name, "coretemp") or std.mem.eql(u8, name, "k10temp")) {
                 const temp_path = std.fmt.bufPrint(&self.cached_path, "/sys/class/hwmon/{s}/temp1_input", .{entry.name}) catch continue;
-                const temp_file = std.fs.openFileAbsolute(temp_path, .{}) catch continue;
-                temp_file.close();
+                const temp_file = std.Io.Dir.openFileAbsolute(io, temp_path, .{}) catch continue;
+                temp_file.close(io);
                 self.cached_path_len = temp_path.len;
                 return true;
             }
@@ -83,15 +81,18 @@ pub const CpuTemp = struct {
         return false;
     }
 
-    pub fn content(self: *CpuTemp, buffer: []u8) []const u8 {
-        if (self.cached_path_len == 0) return buffer[0..0];
+    pub fn content(self: *CpuTemp, io: std.Io, buffer: []u8) []const u8 {
+        if (self.cached_path_len == 0) {
+            self.detectPath(io);
+            if (self.cached_path_len == 0) return buffer[0..0];
+        }
 
         const path = self.cached_path[0..self.cached_path_len];
-        const file = std.fs.openFileAbsolute(path, .{}) catch return buffer[0..0];
-        defer file.close();
+        const file = std.Io.Dir.openFileAbsolute(io, path, .{}) catch return buffer[0..0];
+        defer file.close(io);
 
         var temp_buf: [16]u8 = undefined;
-        const len = file.read(&temp_buf) catch return buffer[0..0];
+        const len = file.readStreaming(io, &.{&temp_buf}) catch return buffer[0..0];
         const temp_str = std.mem.trim(u8, temp_buf[0..len], " \n\r\t");
 
         const millidegrees = std.fmt.parseInt(i32, temp_str, 10) catch return buffer[0..0];

--- a/src/bar/blocks/cpu_temp.zig
+++ b/src/bar/blocks/cpu_temp.zig
@@ -8,6 +8,7 @@ pub const CpuTemp = struct {
     color: c_ulong,
     cached_path: [128]u8,
     cached_path_len: usize,
+    detection_attempted: bool,
 
     pub fn init(
         format: []const u8,
@@ -22,6 +23,7 @@ pub const CpuTemp = struct {
             .color = color,
             .cached_path = undefined,
             .cached_path_len = 0,
+            .detection_attempted = false,
         };
     }
 
@@ -82,10 +84,11 @@ pub const CpuTemp = struct {
     }
 
     pub fn content(self: *CpuTemp, io: std.Io, buffer: []u8) []const u8 {
-        if (self.cached_path_len == 0) {
+        if (!self.detection_attempted) {
             self.detectPath(io);
-            if (self.cached_path_len == 0) return buffer[0..0];
+            self.detection_attempted = true;
         }
+        if (self.cached_path_len == 0) return buffer[0..0];
 
         const path = self.cached_path[0..self.cached_path_len];
         const file = std.Io.Dir.openFileAbsolute(io, path, .{}) catch return buffer[0..0];

--- a/src/bar/blocks/ram.zig
+++ b/src/bar/blocks/ram.zig
@@ -13,12 +13,12 @@ pub const Ram = struct {
         };
     }
 
-    pub fn content(self: *Ram, buffer: []u8) []const u8 {
-        const file = std.fs.openFileAbsolute("/proc/meminfo", .{}) catch return buffer[0..0];
-        defer file.close();
+    pub fn content(self: *Ram, io: std.Io, buffer: []u8) []const u8 {
+        const file = std.Io.Dir.openFileAbsolute(io, "/proc/meminfo", .{}) catch return buffer[0..0];
+        defer file.close(io);
 
         var read_buffer: [512]u8 = undefined;
-        const bytes_read = file.read(&read_buffer) catch return buffer[0..0];
+        const bytes_read = file.readStreaming(io, &.{&read_buffer}) catch return buffer[0..0];
         const file_content = read_buffer[0..bytes_read];
 
         var total: u64 = 0;

--- a/src/bar/blocks/shell.zig
+++ b/src/bar/blocks/shell.zig
@@ -16,14 +16,13 @@ pub const Shell = struct {
         };
     }
 
-    pub fn content(self: *Shell, buffer: []u8) []const u8 {
+    pub fn content(self: *Shell, io: std.Io, gpa: std.mem.Allocator, buffer: []u8) []const u8 {
         var cmd_output: [256]u8 = undefined;
-        const result = std.process.Child.run(.{
-            .allocator = std.heap.page_allocator,
+        const result = std.process.run(gpa, io, .{
             .argv = &.{ "/bin/sh", "-c", self.command },
         }) catch return buffer[0..0];
-        defer std.heap.page_allocator.free(result.stdout);
-        defer std.heap.page_allocator.free(result.stderr);
+        defer gpa.free(result.stdout);
+        defer gpa.free(result.stderr);
 
         var cmd_len = @min(result.stdout.len, cmd_output.len);
         @memcpy(cmd_output[0..cmd_len], result.stdout[0..cmd_len]);

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -218,11 +218,11 @@ pub const Config = struct {
     scheme_occupied: ColorScheme = .{ .foreground = 0x0db9d7, .background = 0x1a1b26, .border = 0x0db9d7 },
     scheme_urgent: ColorScheme = .{ .foreground = 0xf7768e, .background = 0x1a1b26, .border = 0xf7768e },
 
-    keybinds: std.ArrayListUnmanaged(Keybind) = .{},
-    rules: std.ArrayListUnmanaged(Rule) = .{},
-    blocks: std.ArrayListUnmanaged(Block) = .{},
-    buttons: std.ArrayListUnmanaged(MouseButton) = .{},
-    autostart: std.ArrayListUnmanaged([]const u8) = .{},
+    keybinds: std.ArrayListUnmanaged(Keybind) = .empty,
+    rules: std.ArrayListUnmanaged(Rule) = .empty,
+    blocks: std.ArrayListUnmanaged(Block) = .empty,
+    buttons: std.ArrayListUnmanaged(MouseButton) = .empty,
+    autostart: std.ArrayListUnmanaged([]const u8) = .empty,
 
     pub fn init(allocator: std.mem.Allocator) Config {
         return Config{

--- a/src/config/lua.zig
+++ b/src/config/lua.zig
@@ -71,8 +71,8 @@ pub fn loadFile(path: []const u8) bool {
     return true;
 }
 
-pub fn loadConfig() bool {
-    const home = std.posix.getenv("HOME") orelse return false;
+pub fn loadConfig(env: *std.process.Environ.Map) bool {
+    const home = env.get("HOME") orelse return false;
     var path_buf: [512]u8 = undefined;
     const path = std.fmt.bufPrint(&path_buf, "{s}/.config/oxwm/config.lua", .{home}) catch return false;
     return loadFile(path);

--- a/src/keyboard/chord.zig
+++ b/src/keyboard/chord.zig
@@ -22,19 +22,19 @@ pub const ChordState = struct {
     ///
     /// Returns `false` if the sequence is already at maximum length, in which
     /// case the caller should call `reset` before retrying.
-    pub fn push(self: *ChordState, key: config.KeyPress) bool {
+    pub fn push(self: *ChordState, io: std.Io, key: config.KeyPress) bool {
         if (self.index >= max_chord_len) return false;
         self.keys[self.index] = key;
         self.index += 1;
-        self.last_timestamp = std.time.milliTimestamp();
+        self.last_timestamp = std.Io.Timestamp.now(io, .awake).toMilliseconds();
 
         return true;
     }
 
     /// Returns true if the sequence has timed out and should be reset.
-    pub fn isTimedOut(self: *const ChordState) bool {
+    pub fn isTimedOut(self: *const ChordState, io: std.Io) bool {
         if (self.index == 0) return false;
-        return (std.time.milliTimestamp() - self.last_timestamp) >= timeout_ms;
+        return (std.Io.Timestamp.now(io, .awake).toMilliseconds() - self.last_timestamp) >= timeout_ms;
     }
 
     /// Clears the sequence and releases the keyboard grab if one is held.

--- a/src/main.zig
+++ b/src/main.zig
@@ -9,17 +9,16 @@ const lua = @import("config/lua.zig");
 
 const WindowManager = window_manager.WindowManager;
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    const allocator = gpa.allocator();
-    defer _ = gpa.deinit();
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+    const env = init.environ_map;
 
-    const default_config_path = try getConfigPath(allocator);
+    const default_config_path = try getConfigPath(allocator, env);
     defer allocator.free(default_config_path);
 
     var config_path: []const u8 = default_config_path;
     var validate_mode: bool = false;
-    var args = std.process.args();
+    var args = init.minimal.args.iterate();
     _ = args.skip();
     while (args.next()) |arg| {
         if (std.mem.eql(u8, arg, "-c") or std.mem.eql(u8, arg, "--config")) {
@@ -31,7 +30,7 @@ pub fn main() !void {
             std.debug.print("v{s}\n", .{build_options.version});
             return;
         } else if (std.mem.eql(u8, arg, "--init")) {
-            initConfig(allocator);
+            initConfig(allocator, init.io, env);
             return;
         } else if (std.mem.eql(u8, arg, "--validate")) {
             validate_mode = true;
@@ -40,7 +39,7 @@ pub fn main() !void {
     }
 
     if (validate_mode) {
-        try validateConfig(allocator, config_path);
+        try validateConfig(allocator, init.io, config_path);
         return;
     }
 
@@ -49,11 +48,11 @@ pub fn main() !void {
     var config = config_mod.Config.init(allocator);
 
     if (lua.init(&config)) {
-        const loaded = if (std.fs.cwd().statFile(config_path)) |_| blk: {
+        const loaded = if (std.Io.Dir.cwd().statFile(init.io, config_path, .{})) |_| blk: {
             break :blk lua.loadFile(config_path);
         } else |_| blk: {
-            initConfig(allocator);
-            break :blk lua.loadConfig();
+            initConfig(allocator, init.io, env);
+            break :blk lua.loadConfig(env);
         };
 
         if (loaded) {
@@ -67,7 +66,7 @@ pub fn main() !void {
         config_mod.initializeDefaultConfig(&config);
     }
 
-    var wm = WindowManager.init(allocator, config, config_path) catch |err| {
+    var wm = WindowManager.init(allocator, config, config_path, env, init.io) catch |err| {
         std.debug.print("failed to start window manager: {}\n", .{err});
         return;
     };
@@ -114,33 +113,33 @@ fn printHelp() void {
     , .{});
 }
 
-fn initConfig(allocator: std.mem.Allocator) void {
-    const config_path = getConfigPath(allocator) catch return;
+fn initConfig(allocator: std.mem.Allocator, io: std.Io, env: *std.process.Environ.Map) void {
+    const config_path = getConfigPath(allocator, env) catch return;
     defer allocator.free(config_path);
 
     const template = @embedFile("templates/config.lua");
 
     if (std.fs.path.dirname(config_path)) |dir_path| {
-        var root = std.fs.openDirAbsolute("/", .{}) catch |err| {
+        var root = std.Io.Dir.openDirAbsolute(io, "/", .{}) catch |err| {
             std.debug.print("error: could not open root directory: {}\n", .{err});
             return;
         };
-        defer root.close();
+        defer root.close(io);
 
-        const relative_path = std.mem.trimLeft(u8, dir_path, "/");
-        root.makePath(relative_path) catch |err| {
+        const relative_path = std.mem.trimStart(u8, dir_path, "/");
+        root.createDirPath(io, relative_path) catch |err| {
             std.debug.print("error: could not create config directory: {}\n", .{err});
             return;
         };
     }
 
-    const file = std.fs.createFileAbsolute(config_path, .{}) catch |err| {
+    const file = std.Io.Dir.createFileAbsolute(io, config_path, .{}) catch |err| {
         std.debug.print("error: could not create config file: {}\n", .{err});
         return;
     };
-    defer file.close();
+    defer file.close(io);
 
-    _ = file.writeAll(template) catch |err| {
+    file.writeStreamingAll(io, template) catch |err| {
         std.debug.print("error: could not write config file: {}\n", .{err});
         return;
     };
@@ -150,19 +149,15 @@ fn initConfig(allocator: std.mem.Allocator) void {
     std.debug.print("No compilation needed - changes take effect immediately!\n", .{});
 }
 
-fn getConfigPath(allocator: std.mem.Allocator) ![]u8 {
-    const config_home = std.posix.getenv("XDG_CONFIG_HOME") orelse blk: {
-        const home = std.posix.getenv("HOME") orelse return error.CouldNotGetHomeDir;
-        break :blk try std.fs.path.join(allocator, &.{ home, ".config" });
-    };
-    // TODO: wtf is this shit
-    defer if (std.posix.getenv("XDG_CONFIG_HOME") == null) allocator.free(config_home);
-
-    const config_path = try std.fs.path.join(allocator, &.{ config_home, "oxwm", "config.lua" });
-    return config_path;
+fn getConfigPath(allocator: std.mem.Allocator, env: *std.process.Environ.Map) ![]u8 {
+    if (env.get("XDG_CONFIG_HOME")) |xdg| {
+        return std.fs.path.join(allocator, &.{ xdg, "oxwm", "config.lua" });
+    }
+    const home = env.get("HOME") orelse return error.CouldNotGetHomeDir;
+    return std.fs.path.join(allocator, &.{ home, ".config", "oxwm", "config.lua" });
 }
 
-fn validateConfig(allocator: std.mem.Allocator, config_path: []const u8) !void {
+fn validateConfig(allocator: std.mem.Allocator, io: std.Io, config_path: []const u8) !void {
     var config = config_mod.Config.init(allocator);
     defer config.deinit();
 
@@ -172,7 +167,7 @@ fn validateConfig(allocator: std.mem.Allocator, config_path: []const u8) !void {
     }
     defer lua.deinit();
 
-    _ = std.fs.cwd().statFile(config_path) catch |err| {
+    _ = std.Io.Dir.cwd().statFile(io, config_path, .{}) catch |err| {
         std.debug.print("error: config file not found: {s}\n", .{config_path});
         std.debug.print("  {}\n", .{err});
         std.process.exit(1);

--- a/src/wm/actions.zig
+++ b/src/wm/actions.zig
@@ -16,6 +16,7 @@ const WindowManager = wm_mod.WindowManager;
 
 const snap_distance: i32 = 32;
 
+// execvpeZ removed in zig 0.16 std lib rework (codeberg.org/ziglang/zig/issues/31694) with no replacement
 extern "c" fn execvp(file: [*:0]const u8, argv: [*:null]const ?[*:0]const u8) c_int;
 
 pub fn spawnChildSetup(wm: *WindowManager) void {
@@ -801,9 +802,9 @@ pub fn executeAction(action: config_mod.Action, int_arg: i32, str_arg: ?[]const 
                 }
             }
         },
-        .focus_next => focusstack(int_arg, wm),
+        .focus_next => focusstack(if (int_arg == 0) 1 else int_arg, wm),
         .focus_prev => focusstack(-1, wm),
-        .move_next => movestack(int_arg, wm),
+        .move_next => movestack(if (int_arg == 0) 1 else int_arg, wm),
         .move_prev => movestack(-1, wm),
         .resize_master => setmfact(@as(f32, @floatFromInt(int_arg)) / 1000.0, wm),
         .inc_master => incnmaster(1, wm),

--- a/src/wm/actions.zig
+++ b/src/wm/actions.zig
@@ -16,56 +16,58 @@ const WindowManager = wm_mod.WindowManager;
 
 const snap_distance: i32 = 32;
 
+extern "c" fn execvp(file: [*:0]const u8, argv: [*:null]const ?[*:0]const u8) c_int;
+
 pub fn spawnChildSetup(wm: *WindowManager) void {
     _ = std.c.setsid();
-    if (wm.x11_fd >= 0) std.posix.close(@intCast(wm.x11_fd));
+    if (wm.x11_fd >= 0) _ = std.c.close(@intCast(wm.x11_fd));
     const sigchld_handler = std.posix.Sigaction{
         .handler = .{ .handler = std.posix.SIG.DFL },
         .mask = std.mem.zeroes(std.posix.sigset_t),
         .flags = 0,
     };
-    std.posix.sigaction(std.posix.SIG.CHLD, &sigchld_handler, null);
+    std.posix.sigaction(.CHLD, &sigchld_handler, null);
 }
 
 pub fn spawnCommand(wm: *WindowManager, cmd: []const u8) void {
     std.debug.print("running cmd: {s}\n", .{cmd});
-    const pid = std.posix.fork() catch return;
+    const pid = std.c.fork();
+    if (pid < 0) return;
     if (pid == 0) {
-        const grandchild = std.posix.fork() catch std.posix.exit(1);
-        if (grandchild != 0) std.posix.exit(0);
+        const grandchild = std.c.fork();
+        if (grandchild < 0) std.c._exit(1);
+        if (grandchild != 0) std.c._exit(0);
         spawnChildSetup(wm);
         var cmd_buf: [1024]u8 = undefined;
-        if (cmd.len >= cmd_buf.len) {
-            std.posix.exit(1);
-        }
+        if (cmd.len >= cmd_buf.len) std.c._exit(1);
         @memcpy(cmd_buf[0..cmd.len], cmd);
         cmd_buf[cmd.len] = 0;
         const argv = [_:null]?[*:0]const u8{ "sh", "-c", @ptrCast(&cmd_buf) };
-        _ = std.posix.execvpeZ("sh", &argv, std.c.environ) catch {};
-        std.posix.exit(1);
+        _ = execvp("sh", &argv);
+        std.c._exit(1);
     }
-    _ = std.posix.waitpid(pid, 0);
+    _ = std.c.waitpid(pid, null, 0);
 }
 
 pub fn spawnTerminal(wm: *WindowManager) void {
-    const pid = std.posix.fork() catch return;
+    const pid = std.c.fork();
+    if (pid < 0) return;
     if (pid == 0) {
-        const grandchild = std.posix.fork() catch std.posix.exit(1);
-        if (grandchild != 0) std.posix.exit(0);
+        const grandchild = std.c.fork();
+        if (grandchild < 0) std.c._exit(1);
+        if (grandchild != 0) std.c._exit(0);
         spawnChildSetup(wm);
         var term_buf: [256]u8 = undefined;
         const terminal = wm.config.terminal;
-        if (terminal.len >= term_buf.len) {
-            std.posix.exit(1);
-        }
+        if (terminal.len >= term_buf.len) std.c._exit(1);
         @memcpy(term_buf[0..terminal.len], terminal);
         term_buf[terminal.len] = 0;
         const term_ptr: [*:0]const u8 = @ptrCast(&term_buf);
         const argv = [_:null]?[*:0]const u8{term_ptr};
-        _ = std.posix.execvpeZ(term_ptr, &argv, std.c.environ) catch {};
-        std.posix.exit(1);
+        _ = execvp(term_ptr, &argv);
+        std.c._exit(1);
     }
-    _ = std.posix.waitpid(pid, 0);
+    _ = std.c.waitpid(pid, null, 0);
 }
 
 pub fn movestack(direction: i32, wm: *WindowManager) void {
@@ -764,7 +766,7 @@ pub fn reloadLoadConfig(wm: *WindowManager) void {
     const loaded = if (wm.config_path) |path|
         lua.loadFile(path)
     else
-        lua.loadConfig();
+        lua.loadConfig(wm.env);
 
     if (loaded) {
         if (wm.config_path) |path| {

--- a/src/wm/core.zig
+++ b/src/wm/core.zig
@@ -402,7 +402,7 @@ pub fn tickAnimations(wm: *WindowManager) void {
     if (!wm.scroll_animation.isActive()) return;
 
     const monitor = wm.selected_monitor orelse return;
-    if (wm.scroll_animation.update()) |new_offset| {
+    if (wm.scroll_animation.update(wm.io)) |new_offset| {
         monitor.scroll_offset = new_offset;
         arrange(monitor, wm);
     }
@@ -430,7 +430,7 @@ pub fn scrollLayout(direction: i32, wm: *WindowManager) void {
     var target = current + direction * scroll_step;
     target = @max(0, @min(target, max_scroll));
 
-    wm.scroll_animation.start(monitor.scroll_offset, target, wm.animation_config);
+    wm.scroll_animation.start(wm.io, monitor.scroll_offset, target, wm.animation_config);
 }
 
 pub fn scrollToWindow(client: *Client, animate: bool, wm: *WindowManager) void {
@@ -440,7 +440,7 @@ pub fn scrollToWindow(client: *Client, animate: bool, wm: *WindowManager) void {
     const target = scrolling.getTargetScrollForWindow(monitor, client);
 
     if (animate) {
-        wm.scroll_animation.start(monitor.scroll_offset, target, wm.animation_config);
+        wm.scroll_animation.start(wm.io, monitor.scroll_offset, target, wm.animation_config);
     } else {
         monitor.scroll_offset = target;
         arrange(monitor, wm);

--- a/src/wm/handlers.zig
+++ b/src/wm/handlers.zig
@@ -134,11 +134,11 @@ fn handleKeyPress(event: *xlib.XKeyEvent, wm: *WindowManager) void {
 
     const clean_state = event.state & ~@as(c_uint, xlib.LockMask | xlib.Mod2Mask);
 
-    if (wm.chord.isTimedOut()) {
+    if (wm.chord.isTimedOut(wm.io)) {
         wm.chord.reset(wm.display.handle);
     }
 
-    _ = wm.chord.push(.{ .mod_mask = clean_state, .keysym = keysym });
+    _ = wm.chord.push(wm.io, .{ .mod_mask = clean_state, .keysym = keysym });
 
     for (wm.config.keybinds.items) |keybind| {
         if (keybind.key_count == 0) continue;

--- a/src/wm/wm.zig
+++ b/src/wm/wm.zig
@@ -52,6 +52,8 @@ pub const Cursors = struct {
 
 pub const WindowManager = struct {
     allocator: mem.Allocator,
+    env: *std.process.Environ.Map,
+    io: std.Io,
 
     /// The connection to the X server.
     display: Display,
@@ -94,7 +96,7 @@ pub const WindowManager = struct {
     ///
     /// Returns an error if the display cannot be opened or another WM is
     /// already running.
-    pub fn init(allocator: mem.Allocator, config: Config, config_path: ?[]const u8) !WindowManager {
+    pub fn init(allocator: mem.Allocator, config: Config, config_path: ?[]const u8, env: *std.process.Environ.Map, io: std.Io) !WindowManager {
         var display = try Display.open();
         errdefer display.close();
 
@@ -111,6 +113,8 @@ pub const WindowManager = struct {
 
         var wm = WindowManager{
             .allocator = allocator,
+            .env = env,
+            .io = io,
             .display = display,
             .x11_fd = x11_fd,
             .wm_check_window = atoms_result.check_window,
@@ -680,7 +684,7 @@ pub const WindowManager = struct {
 
             var current_bar = self.bars;
             while (current_bar) |bar| {
-                bar.updateBlocks();
+                bar.updateBlocks(self.io, self.allocator);
                 bar.draw(self.display.handle, self.config);
                 current_bar = bar.next;
             }


### PR DESCRIPTION
# Zig 0.16 Migration

Nothing crazy like "WriterGate" but we got some stuff removed from the `std.posix` library, among other things. Notably, the Io changes actually make the clock nicer. Luckily Zig has better C interop than C.

# references

- [Zig 0.16.0 release notes](https://ziglang.org/download/0.16.0/release-notes.html)
- [ziglang/zig#31694 — std lib function relocation](https://codeberg.org/ziglang/zig/issues/31694) — defines the four buckets (std.Io / cross-platform / std.Io.Threaded / simply deleted) and covers everything we lost from `std.posix`

# std lib API moves

| Before | After |
| --- | --- |
| `std.time.milliTimestamp()` | `std.Io.Timestamp.now(io, clock).toMilliseconds()` |
| `std.fs.openFileAbsolute(…)` | `std.Io.Dir.openFileAbsolute(io, …)` |
| `file.read(&buf)` | `file.readStreaming(io, &.{&buf})` |
| `file.writeAll(…)` | `file.writeStreamingAll(io, …)` |
| `Dir.makePath` | `Dir.createDirPath` |
| `std.fs.cwd()` | `std.Io.Dir.cwd()` |
| `std.process.Child.run(.{ .allocator = … })` | `std.process.run(gpa, io, .{})` |
| `std.process.args()` | `init.minimal.args.iterate()` |
| `std.posix.getenv(…)` | `init.environ_map.get(…)` |
| `std.heap.GeneralPurposeAllocator` | `init.gpa` |
| `std.meta.intToEnum` | `std.enums.fromInt` |
| `std.mem.trimLeft` | `std.mem.trimStart` |
| `std.ArrayListUnmanaged(T){}` | `.empty` |
| `posix.sigaction(SIG.CHLD, …)` | `posix.sigaction(.CHLD, …)` (now an enum) |

## libc fallthrough (#31694 "simply deleted" bucket)

`std.posix.execvpeZ` / `fork` / `waitpid` / `setsid` / `_exit` / `close` are gone with no std lib replacement. `src/wm/actions.zig` calls libc directly:

- `extern "c" fn execvp(…) c_int` declared locally
- `std.c.fork` / `setsid` / `waitpid` / `_exit` / `close` in spawn helpers


# worth noting, main changed:

main function changed to take in `std.process.init` so we get `gpa`, `io`, `environ_map`, and `minimal.args` from the it instead of constructing them ourselves.

```zig
pub fn main(init: std.process.init) !void
```


