### PR TITLE
mouse follows monitor swap 

### DIFF
--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -205,6 +205,8 @@ pub const Config = struct {
     hide_vacant_tags: bool = false,
     floating_position: FloatingPosition = .center,
     tiled_resize_mode: bool = false,
+    warp_cursor_to_monitor: bool = false,
+    warp_cursor_on_send: bool = false,
 
     layout_tile_symbol: []const u8 = "[]=",
     layout_monocle_symbol: []const u8 = "[M]",

--- a/src/config/lua.zig
+++ b/src/config/lua.zig
@@ -230,13 +230,19 @@ fn registerTagModule(state: *c.lua_State) void {
 }
 
 fn registerMonitorModule(state: *c.lua_State) void {
-    c.lua_createtable(state, 0, 2);
+    c.lua_createtable(state, 0, 4);
 
     c.lua_pushcfunction(state, luaMonitorFocus);
     c.lua_setfield(state, -2, "focus");
 
     c.lua_pushcfunction(state, luaMonitorTag);
     c.lua_setfield(state, -2, "tag");
+
+    c.lua_pushcfunction(state, luaMonitorWarpCursor);
+    c.lua_setfield(state, -2, "warp_cursor");
+
+    c.lua_pushcfunction(state, luaMonitorWarpCursorOnSend);
+    c.lua_setfield(state, -2, "warp_cursor_on_send");
 
     c.lua_setfield(state, -2, "monitor");
 }
@@ -701,6 +707,20 @@ fn luaMonitorTag(state: ?*c.lua_State) callconv(.c) c_int {
     const dir: i32 = @intCast(c.lua_tointegerx(s, 1, null));
     createActionTableWithInt(s, "TagMonitor", dir);
     return 1;
+}
+
+fn luaMonitorWarpCursor(state: ?*c.lua_State) callconv(.c) c_int {
+    const cfg = config orelse return 0;
+    const s = state orelse return 0;
+    cfg.warp_cursor_to_monitor = c.lua_toboolean(s, 1) != 0;
+    return 0;
+}
+
+fn luaMonitorWarpCursorOnSend(state: ?*c.lua_State) callconv(.c) c_int {
+    const cfg = config orelse return 0;
+    const s = state orelse return 0;
+    cfg.warp_cursor_on_send = c.lua_toboolean(s, 1) != 0;
+    return 0;
 }
 
 fn luaRuleAdd(state: ?*c.lua_State) callconv(.c) c_int {

--- a/src/wm/actions.zig
+++ b/src/wm/actions.zig
@@ -438,6 +438,12 @@ pub fn setLayoutIndex(index: u32, wm: *WindowManager) void {
     }
 }
 
+fn warpCursorToMonitor(monitor: *Monitor, wm: *WindowManager) void {
+    const center_x = monitor.win_x + @divTrunc(monitor.win_w, 2);
+    const center_y = monitor.win_y + @divTrunc(monitor.win_h, 2);
+    _ = xlib.XWarpPointer(wm.display.handle, xlib.None, wm.display.root, 0, 0, 0, 0, center_x, center_y);
+}
+
 pub fn focusmon(direction: i32, wm: *WindowManager) void {
     const selmon = wm.selected_monitor orelse return;
     const target = monitor_mod.dirToMonitor(wm, direction) orelse return;
@@ -447,6 +453,9 @@ pub fn focusmon(direction: i32, wm: *WindowManager) void {
     core.unfocusClient(selmon.sel, false, wm);
     wm.selected_monitor = target;
     core.focus(null, wm);
+    if (wm.config.warp_cursor_to_monitor) {
+        warpCursorToMonitor(target, wm);
+    }
     std.debug.print("focusmon: monitor {d}\n", .{target.num});
 }
 
@@ -469,6 +478,10 @@ pub fn sendmon(direction: i32, wm: *WindowManager) void {
     core.focusTopClient(source_monitor, wm);
     core.arrange(source_monitor, wm);
     core.arrange(target, wm);
+
+    if (wm.config.warp_cursor_on_send) {
+        warpCursorToMonitor(target, wm);
+    }
 
     std.debug.print("sendmon: window=0x{x} to monitor {d}\n", .{ client.window, target.num });
 }

--- a/templates/config.lua
+++ b/templates/config.lua
@@ -267,6 +267,11 @@ oxwm.key.bind({ modkey }, "Period", oxwm.monitor.focus(1))
 oxwm.key.bind({ modkey, "Shift" }, "Comma", oxwm.monitor.tag(-1))
 oxwm.key.bind({ modkey, "Shift" }, "Period", oxwm.monitor.tag(1))
 
+-- Warp the cursor to the focused monitor when switching monitors
+-- oxwm.monitor.warp_cursor(true)
+-- Warp the cursor along when sending a window to another monitor
+-- oxwm.monitor.warp_cursor_on_send(true)
+
 -- Workspace (tag) navigation
 -- Switch to workspace N (tags are 0-indexed, so tag "1" is index 0)
 oxwm.key.bind({ modkey }, "1", oxwm.tag.view(0))

--- a/templates/oxwm.lua
+++ b/templates/oxwm.lua
@@ -204,6 +204,14 @@ function oxwm.monitor.focus(dir) end
 ---@return table Action table for keybinding
 function oxwm.monitor.tag(dir) end
 
+---Warp the cursor to the focused monitor when switching monitors
+---@param enabled boolean
+function oxwm.monitor.warp_cursor(enabled) end
+
+---Warp the cursor along when sending a window to another monitor
+---@param enabled boolean
+function oxwm.monitor.warp_cursor_on_send(enabled) end
+
 ---Layout management module
 ---@class oxwm.layout
 oxwm.layout = {}


### PR DESCRIPTION
closes #221 

added 2 flags to config.lua

```lua
oxwm.monitor.warp_cursor(true)
oxwm.monitor.warp_cursor_on_send(true)
```

1. warp on monitor focus switch
2. warp when sending a window to another monitor
