### PR TITLE
fix: work around FreeBSD math.h incompatibility with Zig translate-c

### DIFF
--- a/src/bar/blocks/datetime.zig
+++ b/src/bar/blocks/datetime.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const format_util = @import("format.zig");
 const c = @cImport({
+    @cDefine("_POSIX_C_SOURCE", "200809L");
     @cInclude("time.h");
 });
 

--- a/src/config/lua.zig
+++ b/src/config/lua.zig
@@ -8,6 +8,7 @@ const Block = config_mod.Block;
 const ColorScheme = config_mod.ColorScheme;
 
 const c = @cImport({
+    @cDefine("_POSIX_C_SOURCE", "200809L");
     @cInclude("lua.h");
     @cInclude("lauxlib.h");
     @cInclude("lualib.h");

--- a/src/x11/xlib.zig
+++ b/src/x11/xlib.zig
@@ -1,4 +1,9 @@
 pub const c = @cImport({
+    // FreeBSD's math.h exposes private inline functions behind __BSD_VISIBLE
+    // that break Zig's translate-c (bitCast with unknown result type).
+    // Setting _POSIX_C_SOURCE restricts visibility to POSIX-only symbols,
+    // hiding the problematic BSD math internals on FreeBSD.
+    @cDefine("_POSIX_C_SOURCE", "200809L");
     @cInclude("X11/Xlib.h");
     @cInclude("X11/Xutil.h");
     @cInclude("X11/Xatom.h");


### PR DESCRIPTION
Hi,

this is a workaround PR for the FreeBSD 15 build failure, also tracked in issue #223.

## Problem

On FreeBSD 15, `<math.h>` exposes private inline functions behind `__BSD_VISIBLE`
that break Zig 0.16.0's `translate-c`, producing the error:

```zig
install
└─ install oxwm
   └─ compile exe oxwm Debug native 1 errors
.zig-cache/o/dd56f764edf921a319c7c8127ca977f0/cimport.zig:3515:33: error: @bitCast must have a known result type
        _bt.*.frac <<= @intCast(@bitCast(@as(c_long, _exp)));
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~
.zig-cache/o/dd56f764edf921a319c7c8127ca977f0/cimport.zig:3515:33: note: use @as to provide explicit result type
error: 1 compilation errors
failed command: /usr/local/bin/zig build-exe -fno-lld .zig-cache/o/90ee13639886076f5be8ef1a095eecab/liblua.a -I/usr/local/include -D_THREAD_SAFE -L/usr/local/lib -lX11 -I/usr/local/include -D_THREAD_SAFE -L/usr/local/lib -lXinerama -I/usr/local/include -D_THREAD_SAFE -I/usr/local/include/freetype2 -I/usr/local/include/libpng16 -L/usr/local/lib -lXft -I/usr/local/include -I/usr/local/include/freetype2 -I/usr/local/include/libpng16 -L/usr/local/lib -lfontconfig -ODebug -I .zig-cache/o/c52c264444049fc528ff2b95369a564b --dep build_options --dep templates/config.lua -Mroot=/home/siput/idkidk/oxwm/src/main.zig -Mbuild_options=.zig-cache/c/26ab746dec7b6e1b212fce1dcad4696f/options.zig -Mtemplates/config.lua=/home/siput/idkidk/oxwm/templates/config.lua -lc --cache-dir .zig-cache --global-cache-dir /home/siput/.cache/zig --name oxwm --zig-lib-dir /usr/local/lib/zig/ --listen=-

Build Summary: 3/6 steps succeeded (1 failed)
install transitive failure
└─ install oxwm transitive failure
   └─ compile exe oxwm Debug native 1 errors

error: the following build command failed with exit code 1:
.zig-cache/o/2ed8efa4e963267402427c16e6aaeb0f/build /usr/local/bin/zig /usr/local/lib/zig /home/siput/idkidk/oxwm .zig-cache /home/siput/.cache/zig --seed 0x4d93abd5 -Zbaf8ed7580c49bb0
```

The root cause is that `<sys/time.h>` leaks FreeBSD kernel-internal `bintime` functions
(`bintime_shift`, `sbintime_getsec`, `bintime_add`, etc.) into the generated `cimport.zig`,
guarded by `__BSD_VISIBLE`. Zig 0.16.0's `translate-c` cannot handle the resulting
`@bitCast` on `struct_bintime.frac` without a known result type.

## Solution

Add `@cDefine("_POSIX_C_SOURCE", "200809L")` before the includes in all three
`@cImport` blocks (`x11/xlib.zig`, `config/lua.zig`, `bar/blocks/datetime.zig`).

This tells system headers to restrict visibility to POSIX.1-2008 symbols,
hiding the problematic BSD-specific math internals on FreeBSD.
On Linux/macOS it's a no-op — X11, fontconfig, and Lua all only use
standard POSIX APIs.

## Future

I expect the FreeBSD and Zig teams will eventually resolve this at the toolchain level,
making this PR obsolete — but until then this workaround is needed.

regards, Siputbiru